### PR TITLE
Override VS Code default CSS rules reverting to initial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Incorrect theme styles caused by VS Code default styles ([#2](https://github.com/marp-team/marp-vscode/issues/2), [#3](https://github.com/marp-team/marp-vscode/pull/3))
+
 ## v0.0.2 - 2019-02-08
 
 ### Fixed

--- a/style.css
+++ b/style.css
@@ -1,10 +1,27 @@
-body.marp-vscode {
-  padding: 0;
-  margin: 0;
-}
-
 #marp-vscode {
   all: initial;
+}
+
+/* Override VS Code default CSS rules reverting to initial */
+/* https://github.com/Microsoft/vscode/blob/master/src/vs/workbench/contrib/webview/electron-browser/webview-pre.js#L412 */
+body.marp-vscode {
+  padding: 0;
+}
+
+body.marp-vscode img {
+  max-width: initial;
+  max-height: initial;
+}
+
+body.marp-vscode a,
+body.marp-vscode a:hover,
+body.marp-vscode code {
+  color: initial;
+}
+
+body.marp-vscode blockquote {
+  background: initial;
+  border-color: initial;
 }
 
 @media screen {

--- a/style.css
+++ b/style.css
@@ -2,8 +2,8 @@
   all: initial;
 }
 
-/* Override VS Code default CSS rules reverting to initial */
-/* https://github.com/Microsoft/vscode/blob/master/src/vs/workbench/contrib/webview/electron-browser/webview-pre.js#L412 */
+/* Override VS Code default CSS rules reverting to initial
+   https://github.com/Microsoft/vscode/blob/master/src/vs/workbench/contrib/webview/electron-browser/webview-pre.js#L412 */
 body.marp-vscode {
   padding: 0;
 }


### PR DESCRIPTION
When enabled Marp VS Code, override several default styles, affected Marp rendering, to the initial value by `initial` keyword.

https://github.com/Microsoft/vscode/blob/92eedf890c66994783e785b00321189d70e55228/src/vs/workbench/contrib/webview/electron-browser/webview-pre.js#L412-L466

Resolves #2.

> **NOTE:** `:focus` pseudo-selectors did not override because the rollbacked values are lacking keyboard accessibility.