### PR TITLE
Revert to use SVG twemoji

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Revert to use SVG twemoji image ([#5](https://github.com/marp-team/marp-vscode/pull/5))
+
 ## v0.0.3 - 2019-02-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Visual Studio Marketplace](https://img.shields.io/visual-studio-marketplace/v/marp-team.marp-vscode.svg?style=flat-square&logo=visual-studio-code&label=VS%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=marp-team.marp-vscode)
 [![LICENSE](https://img.shields.io/github/license/marp-team/marp-vscode.svg?style=flat-square)](./LICENSE)
 
-> :information_source: Marp extension requires VS Code >= 1.31 ([January 2019 release](https://code.visualstudio.com/updates/v1_31)) to install.
+> ℹ️ Marp extension requires VS Code >= 1.31 ([January 2019 release](https://code.visualstudio.com/updates/v1_31)) to install.
 
 **Preview [Marp] Markdown slide deck in VS Code.**
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,6 @@ const marpVscodeEnabled = Symbol()
 export function extendMarkdownIt(md: any) {
   const marp: any = new Marp({
     container: { tag: 'div', id: 'marp-vscode' },
-    emoji: { twemoji: { ext: 'png' } },
   })
 
   md.use(marp.markdownItPlugins)


### PR DESCRIPTION
VS Code 1.31.0 cannot render SVG in Markdown preview pane. We thought that was a default behavior of 1.31 from security reason, but it is just a bug and fixed it at v1.31.1. We will revert twemoji to use SVG instead of PNG.

Related to https://github.com/Microsoft/vscode/issues/68033.

## Screen shot ([yhatt/marp-cli-example](https://github.com/yhatt/marp-cli-example))

|1.31.0|1.31.1|
|:---:|:---:|
|<img width="512" alt="2019-02-13 10 02 58" src="https://user-images.githubusercontent.com/3993388/52678942-aefd6800-2f76-11e9-84b0-e286d5b87d05.png">|<img width="506" alt="2019-02-13 10 03 40" src="https://user-images.githubusercontent.com/3993388/52678945-b58bdf80-2f76-11e9-93d2-804fedfacd3f.png">|
|SVG image (Netlify deploy button) is not rendered, and PNG twemoji has a low resolution.|SVG image can render correctly, and twemoji got a high resolution by SVG.|
