### PR TITLE
Fix misdetection of front-matter in code block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Simplify Marp integration by using independent instance ([#17](https://github.com/marp-team/marp-vscode/pull/17))
 
+### Fixed
+
+- Fix misdetection of front-matter in code block ([#18](https://github.com/marp-team/marp-vscode/pull/18))
+
 ## v0.0.6 - 2019-03-19
 
 ### Added

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -39,19 +39,24 @@ describe('#extendMarkdownIt', () => {
   const marpMd = (md: string) => `---\nmarp: true\n---\n\n${md}`
 
   describe('Marp Core', () => {
-    const markdown = '# Hello :wave:\n\n<!-- header: Hi -->'
+    const baseMd = '# Hello :wave:\n\n<!-- header: Hi -->'
 
-    it('uses default engine without marp front-matter', () => {
-      const html = extendMarkdownIt(new markdownIt()).render(markdown)
+    it('uses default engine when not enabled marp front-matter', () => {
+      const confusingMd =
+        '---\nmarp: false\n---\n\n```markdown\n---\nmarp: true\n---\n```'
 
-      expect(html).not.toContain('<div id="marp-vscode">')
-      expect(html).not.toContain('<style id="marp-vscode-style">')
-      expect(html).not.toContain('svg')
-      expect(html).not.toContain('img')
+      for (const markdown of [baseMd, confusingMd]) {
+        const html = extendMarkdownIt(new markdownIt()).render(markdown)
+
+        expect(html).not.toContain('<div id="marp-vscode">')
+        expect(html).not.toContain('<style id="marp-vscode-style">')
+        expect(html).not.toContain('svg')
+        expect(html).not.toContain('img')
+      }
     })
 
-    it('uses Marp engine with marp front-matter', () => {
-      const html = extendMarkdownIt(new markdownIt()).render(marpMd(markdown))
+    it('uses Marp engine when enabled marp front-matter', () => {
+      const html = extendMarkdownIt(new markdownIt()).render(marpMd(baseMd))
 
       expect(html).toContain('<div id="marp-vscode">')
       expect(html).toContain('<style id="marp-vscode-style">')


### PR DESCRIPTION
When there was front-matter with `marp: true` in code block, Marp for VSCode would misdetect Markdown as Marp slide even if specified `marp: false` in the real front-matter.

    ---
    marp: false
    ---
    
    ```markdown
    ---
    marp: true
    ---
    ```

![marp](https://user-images.githubusercontent.com/3993388/54620070-fb255600-4aa8-11e9-8230-dbaf9c2d8ca5.png)

We must update RegExp for correct front-matter detection.