### PR TITLE
Refresh markdown preview on updating configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Refresh Markdown preview on updating configuration (for VSCode >= 1.34) ([#20](https://github.com/marp-team/marp-vscode/pull/20))
 - Use Marp Core options when rendering by Marp ([#21](https://github.com/marp-team/marp-vscode/pull/21))
 
 ## v0.1.0 - 2019-03-22

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -1,3 +1,4 @@
 export const workspace = {
   getConfiguration: jest.fn(() => new Map()),
+  onDidChangeConfiguration: jest.fn(),
 }

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -32,8 +32,18 @@ beforeEach(() => mockWorkspaceConfig())
 afterEach(() => jest.restoreAllMocks())
 
 describe('#activate', () => {
-  it('contains #extendMarkdownIt', () =>
-    expect(activate()).toEqual(expect.objectContaining({ extendMarkdownIt })))
+  const extContext: any = { subscriptions: { push: jest.fn() } }
+
+  it('contains #extendMarkdownIt', () => {
+    expect(activate(extContext)).toEqual(
+      expect.objectContaining({ extendMarkdownIt })
+    )
+  })
+
+  it('starts tracking to change of configurations', () => {
+    const onDidChgConf = workspace.onDidChangeConfiguration as jest.Mock
+    expect(onDidChgConf).toBeCalledWith(expect.any(Function))
+  })
 })
 
 describe('#extendMarkdownIt', () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,10 +1,11 @@
 import { Marp } from '@marp-team/marp-core'
-import { workspace } from 'vscode'
+import { ExtensionContext, commands, workspace } from 'vscode'
 
 const frontMatterRegex = /^-{3,}\s*([^]*?)^\s*-{3}/m
 const marpDirectiveRegex = /^marp\s*:\s*true\s*$/m
 const marpConfiguration = () => workspace.getConfiguration('markdown.marp')
 const marpVscode = Symbol('marp-vscode')
+const shouldRefreshConfs = ['markdown.marp.enableHtml', 'window.zoomLevel']
 
 const detectMarpFromFrontMatter = (markdown: string): boolean => {
   const m = markdown.match(frontMatterRegex)
@@ -50,4 +51,14 @@ export function extendMarkdownIt(md: any) {
   return md
 }
 
-export const activate = () => ({ extendMarkdownIt })
+export const activate = ({ subscriptions }: ExtensionContext) => {
+  subscriptions.push(
+    workspace.onDidChangeConfiguration(e => {
+      if (shouldRefreshConfs.some(c => e.affectsConfiguration(c))) {
+        commands.executeCommand('markdown.preview.refresh')
+      }
+    })
+  )
+
+  return { extendMarkdownIt }
+}


### PR DESCRIPTION
The scaling bug reported in #8 could still see after changing zoom level. It would return immediately after editing.

The current VS Code cannot render updated Markdown preview with using changed configurations and I reported a request to https://github.com/Microsoft/vscode/issues/70936.

And now, it would be resolved by executing `markdown.preview.refresh` command in VS Code 1.34. This PR will trigger refresh command on changing configurations that are affected to Marp preview.

Currently we have to wait to be released the next insider build for testing this.