### PR TITLE
Use Marp Core options when rendering by Marp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Use Marp Core options when rendering by Marp ([#21](https://github.com/marp-team/marp-vscode/pull/21))
+
 ## v0.1.0 - 2019-03-22
 
 ### Breaking

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,8 +38,9 @@ export function extendMarkdownIt(md: any) {
     const marp = md[marpVscode]
 
     if (marp) {
+      const { markdown } = marp
       const style = marp.renderStyle(marp.lastGlobalDirectives.theme)
-      const html = marp.markdown.renderer.render(tokens, options, env)
+      const html = markdown.renderer.render(tokens, markdown.options, env)
 
       return `<style id="marp-vscode-style">${style}</style>${html}`
     }


### PR DESCRIPTION
A delegated options in `render` is owned by VS Code's markdown renderer. We have to use corresponded Marp Core option when rendering with Marp, but it has been passing the original option wrongly.