### PR TITLE
Add breaks option for Marp Markdown

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,4 +2,3 @@
 coverage/
 lib/
 node_modules
-package.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- A separated breaks option `markdown.marp.breaks` for Marp Markdown ([#16](https://github.com/marp-team/marp-vscode/issues/16), [#22](https://github.com/marp-team/marp-vscode/pull/22))
+
 ### Fixed
 
 - Refresh Markdown preview on updating configuration (for VSCode >= 1.34) ([#20](https://github.com/marp-team/marp-vscode/pull/20))

--- a/package.json
+++ b/package.json
@@ -44,6 +44,21 @@
       "type": "object",
       "title": "Marp for VS Code",
       "properties": {
+        "markdown.marp.breaks": {
+          "type": "string",
+          "enum": [
+            "off",
+            "on",
+            "inherit"
+          ],
+          "default": "on",
+          "description": "Sets how line-breaks are rendered in Marp Markdown. It can set separately because the default setting of Marp ecosystem is different from VS Code.",
+          "enumDescriptions": [
+            "Ignore line-breaks in rendered Marp Markdown preview.",
+            "Show line-breaks in rendered Marp Markdown preview. It is the default setting of Marp ecosystem.",
+            "Use inherited setting from markdown.preview.breaks."
+          ]
+        },
         "markdown.marp.enableHtml": {
           "type": "boolean",
           "default": false,

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -1,3 +1,7 @@
+export const commands = {
+  executeCommand: jest.fn(),
+}
+
 export const workspace = {
   getConfiguration: jest.fn(() => new Map()),
   onDidChangeConfiguration: jest.fn(),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,18 +19,14 @@ const detectMarpFromFrontMatter = (markdown: string): boolean => {
   return !!(m && m.index === 0 && marpDirectiveRegex.exec(m[0].trim()))
 }
 
-const marpOption = (): MarpOptions => {
+const marpOption = (baseOpts): MarpOptions => {
   if (!cachedMarpOption) {
-    const breaks = (() => {
+    const breaks: boolean = (() => {
       switch (marpConfiguration().get<string>('breaks')) {
         case 'off':
           return false
         case 'inherit':
-          return (
-            workspace
-              .getConfiguration('markdown.preview')
-              .get<boolean>('breaks') || false
-          )
+          return baseOpts.breaks
         default:
           return true
       }
@@ -55,7 +51,7 @@ export function extendMarkdownIt(md: any) {
   md.parse = (markdown: string, env: any) => {
     // Generate tokens by Marp if enabled
     if (detectMarpFromFrontMatter(markdown)) {
-      md[marpVscode] = new Marp(marpOption())
+      md[marpVscode] = new Marp(marpOption(md.options))
       return md[marpVscode].markdown.parse(markdown, env)
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,7 @@
-import { Marp } from '@marp-team/marp-core'
+import { Marp, MarpOptions } from '@marp-team/marp-core'
 import { ExtensionContext, commands, workspace } from 'vscode'
+
+let cachedMarpOption: MarpOptions | undefined
 
 const frontMatterRegex = /^-{3,}\s*([^]*?)^\s*-{3}/m
 const marpDirectiveRegex = /^marp\s*:\s*true\s*$/m
@@ -8,13 +10,42 @@ const marpVscode = Symbol('marp-vscode')
 const shouldRefreshConfs = [
   'markdown.marp.breaks',
   'markdown.marp.enableHtml',
-  // 'markdown.preview.breaks',
+  'markdown.preview.breaks',
   'window.zoomLevel',
 ]
 
 const detectMarpFromFrontMatter = (markdown: string): boolean => {
   const m = markdown.match(frontMatterRegex)
   return !!(m && m.index === 0 && marpDirectiveRegex.exec(m[0].trim()))
+}
+
+const marpOption = (): MarpOptions => {
+  if (!cachedMarpOption) {
+    const breaks = (() => {
+      switch (marpConfiguration().get<string>('breaks')) {
+        case 'off':
+          return false
+        case 'inherit':
+          return (
+            workspace
+              .getConfiguration('markdown.preview')
+              .get<boolean>('breaks') || false
+          )
+        default:
+          return true
+      }
+    })()
+
+    const zoom =
+      workspace.getConfiguration('window').get<number>('zoomLevel') || 0
+
+    cachedMarpOption = {
+      container: { tag: 'div', id: 'marp-vscode', 'data-zoom': 1.2 ** zoom },
+      html: marpConfiguration().get<boolean>('enableHtml') || undefined,
+      markdown: { breaks },
+    }
+  }
+  return cachedMarpOption
 }
 
 export function extendMarkdownIt(md: any) {
@@ -24,29 +55,7 @@ export function extendMarkdownIt(md: any) {
   md.parse = (markdown: string, env: any) => {
     // Generate tokens by Marp if enabled
     if (detectMarpFromFrontMatter(markdown)) {
-      const breaks = (() => {
-        const marpBreaks = marpConfiguration().get<string>('breaks')
-
-        if (marpBreaks === 'off') return false
-        if (marpBreaks === 'inherit') {
-          return (
-            workspace
-              .getConfiguration('markdown.preview')
-              .get<boolean>('breaks') || false
-          )
-        }
-        return true
-      })()
-
-      const zoom =
-        workspace.getConfiguration('window').get<number>('zoomLevel') || 0
-
-      md[marpVscode] = new Marp({
-        container: { tag: 'div', id: 'marp-vscode', 'data-zoom': 1.2 ** zoom },
-        html: marpConfiguration().get<boolean>('enableHtml') || undefined,
-        markdown: { breaks },
-      })
-
+      md[marpVscode] = new Marp(marpOption())
       return md[marpVscode].markdown.parse(markdown, env)
     }
 
@@ -76,6 +85,7 @@ export const activate = ({ subscriptions }: ExtensionContext) => {
   subscriptions.push(
     workspace.onDidChangeConfiguration(e => {
       if (shouldRefreshConfs.some(c => e.affectsConfiguration(c))) {
+        cachedMarpOption = undefined
         commands.executeCommand('markdown.preview.refresh')
       }
     })


### PR DESCRIPTION
This PR adds `markdown.marp.breaks` configuration to control rendering of line-breaks in Marp Markdown separately from VS Code's configuration. It allows 3 options:

- `off`: Ignore line-breaks in rendered Marp preview.
- `on`: Show line-breaks in rendered Marp preview.
- `inherit`: Use inherited setting from `markdown.preview.breaks`.

To suit to Marp Core and the other tools, the default value is `on`.

Resolves #16.

<img width="488" alt="breaks" src="https://user-images.githubusercontent.com/3993388/55691548-2cbf7c00-59da-11e9-9726-3f039ff02283.png">

## ToDo

- [x] Fix warning in getting configuration of `markdown.preview.breaks` (It should specify resource)
  - 👉 VS Code's Markdown extension cannot get current resource URI. We use the passed option to markdown-it instead of configuration value.