### PR TITLE
Re-implement line number mapping to preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Improve scroll sync by re-implemented line number mapping to each page ([#25](https://github.com/marp-team/marp-vscode/pull/25))
+
 ## v0.2.0 - 2019-04-10
 
 ### Added

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import { Marp, MarpOptions } from '@marp-team/marp-core'
 import { ExtensionContext, commands, workspace } from 'vscode'
+import lineNumber from './plugins/line-number'
 import outline from './plugins/outline'
 
 let cachedMarpOption: MarpOptions | undefined
@@ -52,7 +53,10 @@ export function extendMarkdownIt(md: any) {
   md.parse = (markdown: string, env: any) => {
     // Generate tokens by Marp if enabled
     if (detectMarpFromFrontMatter(markdown)) {
-      md[marpVscode] = new Marp(marpOption(md.options)).use(outline)
+      md[marpVscode] = new Marp(marpOption(md.options))
+        .use(outline)
+        .use(lineNumber)
+
       return md[marpVscode].markdown.parse(markdown, env)
     }
 

--- a/src/plugins/line-number.ts
+++ b/src/plugins/line-number.ts
@@ -1,0 +1,17 @@
+export default function marpVSCodeLineNumber(md) {
+  const { marpit_inline_svg_open } = md.renderer.rules
+
+  md.renderer.rules.marpit_inline_svg_open = (tokens, idx, opts, env, self) => {
+    const slide = tokens
+      .slice(idx + 1)
+      .find(t => t.type === 'marpit_slide_open')
+
+    if (slide.map && slide.map.length) {
+      tokens[idx].attrJoin('class', 'code-line')
+      tokens[idx].attrSet('data-line', slide.map[0])
+    }
+
+    const renderer = marpit_inline_svg_open || self.renderToken
+    return renderer.call(self, tokens, idx, opts, env, self)
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1979,9 +1979,9 @@ growly@^1.3.0:
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
 handlebars@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.1.tgz#6e4e41c18ebe7719ae4d38e5aca3d32fa3dd23d3"
-  integrity sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
+  integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"


### PR DESCRIPTION
Line mapping had lost by splitting out markdown-it engine since v0.1.0. A new line number plugin adds the data of line number to output HTML, to tell mapped line of Markdown to rendered slide.

It will improve two important features of VS Code's Markdown support. 

- Editor always will scroll to top when enabled `markdown.preview.scrollEditorWithPreview` and scrolled Markdown preview. It would block users work 😢
- A regular Markdown preview supports going from any elements to the corresponded line when enabled `markdown.preview.doubleClickToSwitchToEditor`. It already can switch to the editor but going to top by the same reason.

The added plugin map the line data only to the slide. We've tried to map all supported elements as same as VS Code's default, but elements on the preview show incorrect position because of effect by SVG polyfill for WebKit ([@marp-team/marpit-svg-polyfill](https://github.com/marp-team/marpit-svg-polyfill)).

![marp-vscode](https://user-images.githubusercontent.com/3993388/55971721-01c87700-5cbd-11e9-8235-0d24db2edec2.png)

