### PR TITLE
Improve engine compatibility with VS Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Improve scroll sync by re-implemented line number mapping to each page ([#25](https://github.com/marp-team/marp-vscode/pull/25))
+- Improve engine compatibility with VS Code ([#27](https://github.com/marp-team/marp-vscode/pull/27))
 
 ## v0.2.0 - 2019-04-10
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,6 +53,17 @@ export function extendMarkdownIt(md: any) {
     // Generate tokens by Marp if enabled
     if (detectMarpFromFrontMatter(markdown)) {
       md[marpVscode] = new Marp(marpOption(md.options)).use(outline)
+
+      const marpMarkdown = md[marpVscode].markdown
+
+      // Use image stabilizer and link normalizer from VS Code
+      marpMarkdown.renderer.rules.image = md.renderer.rules.image
+      marpMarkdown.normalizeLink = md.normalizeLink
+
+      // validateLink prefers Marp's default. If overridden by VS Code's it,
+      // does not return compatible result with the other Marp tools.
+      // marpMarkdown.validateLink = md.validateLink
+
       return md[marpVscode].markdown.parse(markdown, env)
     }
 


### PR DESCRIPTION
As same as #25, Marp engine since v0.1.0 had lost some internal compatibillities with VS Code's default markdown-it.

This PR will apply a few settings of the original engine: Image renderer with stabilizer, and link normalizer with `vscode` scheme support.

> Currently an original link validator is not applied to Marp because it would be over-recognized the unsupported URL-like text.