### PR TITLE
Improve activation performance of extension by lazy-loaded Marp CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Improve activation performance of extension by lazy-loaded Marp CLI ([#37](https://github.com/marp-team/marp-vscode/pull/37))
+
 ## v0.4.0 - 2019-05-13
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -169,12 +169,14 @@
     "watch": "rollup -w -c ./rollup.config.js"
   },
   "devDependencies": {
+    "@marp-team/marpit-svg-polyfill": "^0.3.0",
     "@types/jest": "^24.0.12",
     "@types/markdown-it": "^0.0.7",
     "codecov": "^3.4.0",
     "jest": "^24.8.0",
     "jest-junit": "^6.4.0",
     "markdown-it": "^8.4.2",
+    "nanoid": "^2.0.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.17.0",
     "rimraf": "^2.6.3",
@@ -196,8 +198,6 @@
   },
   "dependencies": {
     "@marp-team/marp-cli": "^0.9.2",
-    "@marp-team/marp-core": "^0.9.0",
-    "@marp-team/marpit-svg-polyfill": "^0.3.0",
-    "nanoid": "^2.0.1"
+    "@marp-team/marp-core": "^0.9.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,6 +20,7 @@ export default [
   {
     external: [
       ...Object.keys(pkg.dependencies),
+      'crypto',
       'fs',
       'os',
       'path',

--- a/src/marp-cli.test.ts
+++ b/src/marp-cli.test.ts
@@ -1,6 +1,7 @@
 // tslint:disable-next-line: import-name
 import * as marpCliModule from '@marp-team/marp-cli'
 import fs from 'fs'
+import path from 'path'
 import { tmpdir } from 'os'
 import { workspace } from 'vscode'
 import * as marpCli from './marp-cli'
@@ -72,7 +73,9 @@ describe('#createWorkFile', () => {
       uri: { scheme: 'file', fsPath: '/tmp/dirty.md' },
     } as any)
 
-    expect(workFile.path).toMatch(/^\/tmp\/\.marp-vscode-tmp.+$/)
+    expect(
+      workFile.path.startsWith(path.join('/tmp', '.marp-vscode-tmp'))
+    ).toBe(true)
     expect(fsMock.writeFile).toBeCalledWith(
       workFile.path,
       'example',
@@ -101,7 +104,9 @@ describe('#createWorkFile', () => {
       uri: { scheme: 'file', fsPath: '/workspace/tmp/dirty.md' },
     } as any)
 
-    expect(workFile.path).toMatch(/^\/workspace\/\.marp-vscode-tmp.+$/)
+    expect(
+      workFile.path.startsWith(path.join('/workspace', '.marp-vscode-tmp'))
+    ).toBe(true)
   })
 
   it('creates tmpfile to os specific directory when failed all creations', async () => {

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -12,6 +12,9 @@ interface WorkFile {
   cleanup: () => Promise<void>
 }
 
+const marpCliAsync = async (): Promise<typeof marpCli> =>
+  (await import('@marp-team/marp-cli')).default
+
 export class MarpCLIError extends Error {}
 
 export async function createWorkFile(doc: TextDocument): Promise<WorkFile> {
@@ -82,7 +85,8 @@ export default async function runMarpCli(...opts: string[]): Promise<void> {
   }
 
   try {
-    const exitCode = await marpCli(argv)
+    const marpCliInstance = await marpCliAsync()
+    const exitCode = await marpCliInstance(argv)
 
     if (exitCode !== 0) {
       for (const err of errors) {


### PR DESCRIPTION
Marp CLI integration since v0.3.0 was degraded activation performance of extension. It takes a time about 3 times to activate Marp for VS Code.

So we have applied lazy loading to Marp CLI.  It is about 150% faster than v0.4.0, and returns to a good performance as like as v0.2.1. (Used the measured activation time in `Developer: Show Running Extensions`)