### PR TITLE
Fix Markdown link normalization to suit to Marpit color shorthand

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "@types/jest": "^24.0.12",
     "@types/markdown-it": "^0.0.7",
     "codecov": "^3.4.0",
+    "color-string": "^1.5.3",
     "jest": "^24.8.0",
     "jest-junit": "^6.4.0",
     "markdown-it": "^8.4.2",

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -57,6 +57,19 @@ describe('#extendMarkdownIt', () => {
       expect(html).toContain('svg')
       expect(html).toContain('img')
     })
+
+    it('renders resources with correct normalization', () => {
+      const md = new markdownIt()
+      md.normalizeLink = url => `vscode-resource:${url}`
+
+      const html = extendMarkdownIt(md).render(
+        marpMd('![bg](test.png)![bg](white)![](#000)')
+      )
+
+      expect(html).toContain('vscode-resource:test.png')
+      expect(html).toContain('color:#000;')
+      expect(html).toContain('background-color:white;')
+    })
   })
 
   describe('Workspace config', () => {


### PR DESCRIPTION
Improvement of VS Code engine compatibility (#27) causes regression of Marpit color shorthand. We are fixed this by checking color string in `normalizeLink` method.

Fixes #40.