### PR TITLE
Add markdown.marp.chromePath preference to allow setting Chrome custom path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add `markdown.marp.chromePath` preference to allow setting custom Chrome path ([#44](https://github.com/marp-team/marp-vscode/issues/44), [#46](https://github.com/marp-team/marp-vscode/pull/46))
+
 ## v0.5.0 - 2019-06-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ You can also execute command from the Command Palette (<kbd>F1</kbd> or <kbd>Ctr
 - **HTML**: for playing your deck on the browser
 - **PNG**, **JPEG** (_First slide only)_: for creating an image of title slide
 
-> ⚠️ Export to PDF and image formats requires to install [Google Chrome](https://www.google.com/chrome/) (or [Chromium](https://www.chromium.org/)).
+> ⚠️ Export to PDF and image formats requires to install [Google Chrome](https://www.google.com/chrome/) (or [Chromium](https://www.chromium.org/)). You may also specify the custom path for Chrome and Chromium-based browser by preference `markdown.marp.chromePath` (e.g. [Microsoft Edge Insider](https://www.microsoftedgeinsider.com/)).
 
 ### Outline view for each slide
 

--- a/package.json
+++ b/package.json
@@ -78,6 +78,11 @@
             "Use inherited setting from markdown.preview.breaks."
           ]
         },
+        "markdown.marp.chromePath": {
+          "type": "string",
+          "default": "",
+          "description": "Sets the custom path for Chrome or Chromium-based browser to export PDF and image. If it's empty, Marp will find out the installed Google Chrome."
+        },
         "markdown.marp.enableHtml": {
           "type": "boolean",
           "default": false,

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -3,6 +3,7 @@ type MockedConf = Record<string, any>
 
 const defaultConf: MockedConf = {
   'markdown.marp.breaks': 'on',
+  'markdown.marp.chromePath': '',
   'markdown.marp.enableHtml': false,
   'window.zoomLevel': 0,
 }

--- a/src/marp-cli.test.ts
+++ b/src/marp-cli.test.ts
@@ -8,6 +8,9 @@ import * as marpCli from './marp-cli'
 
 jest.mock('vscode')
 
+const setConfiguration: (conf?: object) => void = (workspace as any)
+  ._setConfiguration
+
 describe('Marp CLI integration', () => {
   const runMarpCli = marpCli.default
 
@@ -37,6 +40,26 @@ describe('Marp CLI integration', () => {
     })
 
     expect(runMarpCli('--version')).rejects.toThrow(/Google Chrome/)
+  })
+
+  describe('with markdown.marp.chromePath preference', () => {
+    it('runs Marp CLI with overridden CHROME_PATH environment', async () => {
+      const { CHROME_PATH } = process.env
+      expect(process.env.CHROME_PATH).toBe(CHROME_PATH)
+
+      setConfiguration({ 'markdown.marp.chromePath': __filename })
+
+      const marpCliSpy = jest
+        .spyOn(marpCliModule, 'default')
+        .mockImplementation(async () => {
+          expect(process.env.CHROME_PATH).toBe(__filename)
+          return 0
+        })
+
+      await runMarpCli('--version')
+      expect(marpCliSpy).toBeCalled()
+      expect(process.env.CHROME_PATH).toBe(CHROME_PATH)
+    })
   })
 })
 

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -93,6 +93,7 @@ export default async function runMarpCli(...opts: string[]): Promise<void> {
     try {
       process.env.CHROME_PATH =
         marpConfiguration().get<string>('chromePath') || CHROME_PATH
+
       exitCode = await marpCliInstance(argv)
     } finally {
       process.env.CHROME_PATH = CHROME_PATH

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'os'
 import path from 'path'
 import { promisify } from 'util'
 import { TextDocument, workspace } from 'vscode'
-import { marpCoreOptionForCLI } from './option'
+import { marpConfiguration, marpCoreOptionForCLI } from './option'
 
 interface WorkFile {
   path: string
@@ -86,7 +86,16 @@ export default async function runMarpCli(...opts: string[]): Promise<void> {
 
   try {
     const marpCliInstance = await marpCliAsync()
-    const exitCode = await marpCliInstance(argv)
+    const { CHROME_PATH } = process.env
+
+    let exitCode: number
+
+    try {
+      process.env.CHROME_PATH = marpConfiguration().get<string>('chromePath')
+      exitCode = await marpCliInstance(argv)
+    } finally {
+      process.env.CHROME_PATH = CHROME_PATH
+    }
 
     if (exitCode !== 0) {
       for (const err of errors) {

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -91,7 +91,8 @@ export default async function runMarpCli(...opts: string[]): Promise<void> {
     let exitCode: number
 
     try {
-      process.env.CHROME_PATH = marpConfiguration().get<string>('chromePath')
+      process.env.CHROME_PATH =
+        marpConfiguration().get<string>('chromePath') || CHROME_PATH
       exitCode = await marpCliInstance(argv)
     } finally {
       process.env.CHROME_PATH = CHROME_PATH


### PR DESCRIPTION
The added preference `markdown.marp.chromePath` can set the custom Chrome path to export PDF and image. If it's empty or not executable, Marp CLI would fallback to the installed Google Chrome.

For example, the user can swap the PDF export engine to [Microsoft Edge Insider](https://www.microsoftedgeinsider.com/en-us/).

![Extension Development Host  - Settings - Visual Studio Code - Insiders 2019_06_11 0_15_35](https://user-images.githubusercontent.com/3993388/59206175-5ca81d00-8bdf-11e9-92ff-5b82e4af3152.png)

Resolves #44.

### ToDo

- [x] Add unit test