### PR TITLE
Apply better scroll-sync when Marpit polyfill is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix wrong hit area for link caused by Marpit polyfill when using VS Code >= 1.36 ([#45](https://github.com/marp-team/marp-vscode/issues/45), [#49](https://github.com/marp-team/marp-vscode/pull/49))
+- Better scroll-sync when using VS Code >= 1.36 ([#50](https://github.com/marp-team/marp-vscode/pull/50))
 
 ## v0.5.1 - 2019-06-12
 

--- a/package.json
+++ b/package.json
@@ -175,10 +175,13 @@
   },
   "devDependencies": {
     "@marp-team/marpit-svg-polyfill": "^0.3.0",
+    "@types/cheerio": "^0.22.11",
     "@types/jest": "^24.0.13",
     "@types/markdown-it": "^0.0.7",
     "@types/semver": "^6.0.0",
+    "cheerio": "^1.0.0-rc.3",
     "codecov": "^3.5.0",
+    "dedent": "^0.7.0",
     "jest": "^24.8.0",
     "jest-junit": "^6.4.0",
     "markdown-it": "^8.4.2",

--- a/src/option.ts
+++ b/src/option.ts
@@ -6,6 +6,8 @@ import { MarpOptions } from '@marp-team/marp-core'
 let cachedPreviewOption: MarpOptions | undefined
 let cachedCLIOption: any
 
+const coercedVer = coerce(version)
+
 // WebKit polyfill requires in VS Code < 1.36 (Electron 3).
 //
 // NOTE: Electron 3 has got a stable rendering by applying WebKit polyfill. And
@@ -13,8 +15,7 @@ let cachedCLIOption: any
 // remains glitch when used CSS 3D transform and video component. Electron 5
 // also has a glitch in video, and we have to wait for stable rendering until
 // Electron 6.
-const coercedVer = coerce(version)
-const isRequiredPolyfill = coercedVer ? lt(coercedVer, '1.36.0') : false
+export const isRequiredPolyfill = coercedVer ? lt(coercedVer, '1.36.0') : false
 
 export const marpConfiguration = () =>
   workspace.getConfiguration('markdown.marp')

--- a/src/plugins/line-number.ts
+++ b/src/plugins/line-number.ts
@@ -1,6 +1,8 @@
 import { isRequiredPolyfill } from '../option'
 
-// https://github.com/microsoft/vscode/blob/master/extensions/markdown-language-features/src/markdownEngine.ts
+// Based on the original line-number rendering rule of VS Code.
+// https://github.com/microsoft/vscode/blob/5466f27d95c52e8d7c34ed445c682b5d71f049d9/extensions/markdown-language-features/src/markdownEngine.ts#L102-L104
+
 const rules = [
   'paragraph_open',
   'heading_open',

--- a/src/plugins/line-number.ts
+++ b/src/plugins/line-number.ts
@@ -1,6 +1,20 @@
+import { isRequiredPolyfill } from '../option'
+
+// https://github.com/microsoft/vscode/blob/master/extensions/markdown-language-features/src/markdownEngine.ts
+const rules = [
+  'paragraph_open',
+  'heading_open',
+  'image',
+  'code_block',
+  'fence',
+  'blockquote_open',
+  'list_item_open',
+]
+
 export default function marpVSCodeLineNumber(md) {
   const { marpit_inline_svg_open } = md.renderer.rules
 
+  // Enable line sync by per slides
   md.renderer.rules.marpit_inline_svg_open = (tokens, idx, opts, env, self) => {
     const slide = tokens
       .slice(idx + 1)
@@ -13,5 +27,25 @@ export default function marpVSCodeLineNumber(md) {
 
     const renderer = marpit_inline_svg_open || self.renderToken
     return renderer.call(self, tokens, idx, opts, env, self)
+  }
+
+  // Enables better line sync only when disabled poiyfill 
+  // (There are wrong DOM positions if enabled polyfill)
+  if (!isRequiredPolyfill) {
+    for (const rule of rules) {
+      const original = md.renderer.rules[rule]
+
+      md.renderer.rules[rule] = (tokens, idx, options, env, self) => {
+        const token = tokens[idx]
+
+        if (token.map && token.map.length) {
+          token.attrJoin('class', 'code-line')
+          token.attrSet('data-line', token.map[0])
+        }
+
+        const renderer = original || self.renderToken
+        return renderer.call(self, tokens, idx, options, env, self)
+      }
+    }
   }
 }

--- a/src/plugins/line-number.ts
+++ b/src/plugins/line-number.ts
@@ -29,7 +29,7 @@ export default function marpVSCodeLineNumber(md) {
     return renderer.call(self, tokens, idx, opts, env, self)
   }
 
-  // Enables better line sync only when disabled poiyfill 
+  // Enables better line sync only when disabled poiyfill
   // (There are wrong DOM positions if enabled polyfill)
   if (!isRequiredPolyfill) {
     for (const rule of rules) {

--- a/src/plugins/line-number.ts
+++ b/src/plugins/line-number.ts
@@ -29,7 +29,7 @@ export default function marpVSCodeLineNumber(md) {
     return renderer.call(self, tokens, idx, opts, env, self)
   }
 
-  // Enables better line sync only when disabled poiyfill
+  // Enables better line sync only when disabled polyfill
   // (There are wrong DOM positions if enabled polyfill)
   if (!isRequiredPolyfill) {
     for (const rule of rules) {

--- a/style.css
+++ b/style.css
@@ -35,7 +35,7 @@ body.marp-vscode blockquote {
     margin: 20px;
   }
 
-  #marp-vscode svg[data-marpit-svg] > foreignobject > section {
+  #marp-vscode[data-polyfill] svg[data-marpit-svg] > foreignobject > section {
     /* Workaround for wrong hit area caused by Chromium's rendering bug */
     overflow: visible;
   }
@@ -70,7 +70,7 @@ body.marp-vscode blockquote {
     display: none;
   }
 
-  #marp-vscode svg[data-marpit-svg] > foreignobject > section {
+  #marp-vscode[data-polyfill] svg[data-marpit-svg] > foreignobject > section {
     /* Disable WebKit polyfill */
     transform: none !important;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -415,6 +415,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/cheerio@^0.22.11":
+  version "0.22.11"
+  resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.11.tgz#61c0facf9636d14ba5f77fc65ed8913aa845d717"
+  integrity sha512-x0X3kPbholdJZng9wDMhb2swvUi3UYRNAuWAmIPIWlfgAJZp//cql/qblE7181Mg7SjWVwq6ldCPCLn5AY/e7w==
+  dependencies:
+    "@types/node" "*"
+
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
@@ -887,6 +894,11 @@ body-parser@1.19.0:
     raw-body "2.4.0"
     type-is "~1.6.17"
 
+boolbase@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+  integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -1099,6 +1111,18 @@ character-reference-invalid@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz#1647f4f726638d3ea4a750cf5d1975c1c7919a85"
   integrity sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg==
+
+cheerio@^1.0.0-rc.3:
+  version "1.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.3.tgz#094636d425b2e9c0f4eb91a46c05630c9a1a8bf6"
+  integrity sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==
+  dependencies:
+    css-select "~1.2.0"
+    dom-serializer "~0.1.1"
+    entities "~1.1.1"
+    htmlparser2 "^3.9.1"
+    lodash "^4.15.0"
+    parse5 "^3.0.1"
 
 chokidar@^3.0.1:
   version "3.0.1"
@@ -1334,6 +1358,21 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+css-select@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
+  integrity sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=
+  dependencies:
+    boolbase "~1.0.0"
+    css-what "2.1"
+    domutils "1.5.1"
+    nth-check "~1.0.1"
+
+css-what@2.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
+  integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
+
 cssfilter@0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/cssfilter/-/cssfilter-0.0.10.tgz#c6d2672632a2e5c83e013e6864a42ce8defd20ae"
@@ -1419,6 +1458,11 @@ decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+
+dedent@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
+  integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
 deep-extend@^0.6.0:
   version "0.6.0"
@@ -1524,7 +1568,7 @@ doctrine@0.7.2:
     esutils "^1.1.6"
     isarray "0.0.1"
 
-dom-serializer@0:
+dom-serializer@0, dom-serializer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
   integrity sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==
@@ -1549,6 +1593,14 @@ domhandler@^2.3.0:
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.4.2.tgz#8805097e933d65e85546f726d60f5eb88b44f803"
   integrity sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
   dependencies:
+    domelementtype "1"
+
+domutils@1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+  integrity sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=
+  dependencies:
+    dom-serializer "0"
     domelementtype "1"
 
 domutils@^1.5.1:
@@ -2311,7 +2363,7 @@ html-tags@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-2.0.0.tgz#10b30a386085f43cede353cc8fa7cb0deeea668b"
   integrity sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos=
 
-htmlparser2@^3.10.0:
+htmlparser2@^3.10.0, htmlparser2@^3.9.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
   integrity sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
@@ -3415,7 +3467,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.11:
+lodash@^4.15.0, lodash@^4.17.11:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -3952,6 +4004,13 @@ npmlog@^4.0.2:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
+nth-check@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
+  integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
+  dependencies:
+    boolbase "~1.0.0"
+
 num2fraction@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
@@ -4163,6 +4222,13 @@ parse5@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
   integrity sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==
+
+parse5@^3.0.1:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
+  integrity sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==
+  dependencies:
+    "@types/node" "*"
 
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"


### PR DESCRIPTION
Add the support of better scroll-sync when Marpit polyfill is disabled.

Rendered DOMs on preview have the correct calculated position when polyfill is not applied. So we can annotate to DOM for more accurately scroll-sync by line as same as [VS Code default](https://github.com/microsoft/vscode/blob/09158c5b7aefa2de9e66f4905d67c6c4a54fbe6c/extensions/markdown-language-features/src/markdownEngine.ts#L167-L182).