### PR TITLE
Fix regression of not working size global directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix regression of not working `size` global directive ([#61](https://github.com/marp-team/marp-vscode/issues/61), [#62](https://github.com/marp-team/marp-vscode/pull/62))
+
 ## v0.8.0 - 2019-07-29
 
 ### Added

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import path from 'path'
+import { Marp } from '@marp-team/marp-core'
 import axios from 'axios'
 import cheerio from 'cheerio'
 import dedent from 'dedent'
@@ -87,6 +88,25 @@ describe('#extendMarkdownIt', () => {
   })
 
   describe('Plugins', () => {
+    describe('Custom theme', () => {
+      const marpCore = (markdown: string = ''): Marp => {
+        const { extendMarkdownIt, marpVscode } = extension()
+        const md = new markdownIt()
+
+        extendMarkdownIt(md).render(marpMd(markdown))
+        return md[marpVscode]
+      }
+
+      it('prevents override built-in theme', () => {
+        expect(() => marpCore().themeSet.add('/* @theme default */')).toThrow()
+        expect(() => marpCore().themeSet.add('/* @theme gaia */')).toThrow()
+        expect(() => marpCore().themeSet.add('/* @theme uncover */')).toThrow()
+      })
+
+      it('works size global directive correctly', () =>
+        expect(() => marpCore('<!-- size: 4:3 -->')).not.toThrow())
+    })
+
     describe('Line number', () => {
       const markdown = dedent`
         ---

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,6 @@ import themes from './themes'
 
 const frontMatterRegex = /^-{3,}\s*([^]*?)^\s*-{3}/m
 const marpDirectiveRegex = /^marp\s*:\s*true\s*$/m
-const marpVscode = Symbol('marp-vscode')
 const shouldRefreshConfs = [
   'markdown.marp.breaks',
   'markdown.marp.enableHtml',
@@ -23,6 +22,8 @@ const detectMarpFromFrontMatter = (markdown: string): boolean => {
   const m = markdown.match(frontMatterRegex)
   return !!(m && m.index === 0 && marpDirectiveRegex.exec(m[0].trim()))
 }
+
+export const marpVscode = Symbol('marp-vscode')
 
 export function extendMarkdownIt(md: any) {
   const { parse, renderer } = md

--- a/src/plugins/custom-theme.ts
+++ b/src/plugins/custom-theme.ts
@@ -1,16 +1,31 @@
 export class CustomThemeError extends Error {}
 
-export default function marpVSCodeCustomTheme({ marpit }) {
+export default function marpVSCodeCustomTheme(instance) {
+  const { marpit, parse } = instance
   const registeredThemes = [...marpit.themeSet.themes()].map(t => t.name)
   const { addTheme } = marpit.themeSet
 
+  // `size` global directive support in Marp Core may override an instance of
+  // default themes. Even if default themes were overridden, we should not throw
+  // error while parsing Markdown by markdown-it.
+  let whileParsing = false
+
   marpit.themeSet.addTheme = theme => {
-    if (registeredThemes.includes(theme.name)) {
+    if (!whileParsing && registeredThemes.includes(theme.name)) {
       throw new CustomThemeError(
         `Custom theme cannot override "${theme.name}" built-in theme.`
       )
     } else {
       return addTheme.call(marpit.themeSet, theme)
+    }
+  }
+
+  instance.parse = (...args) => {
+    try {
+      whileParsing = true
+      return parse.apply(instance, args)
+    } finally {
+      whileParsing = false
     }
   }
 }


### PR DESCRIPTION
Fixes #61.

Marp for VS Code has custom theme plugin to prevent overriding built-in theme. However, it is conflicting with the support for `size` global directive in Marp Core.

Now we fixed the plugin to allow override a built-in theme while parsing Markdown.