### PR TITLE
Disable style minification on preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Upgrade Marp Core to [v0.13.1](https://github.com/marp-team/marp-core/releases/v0.13.1) and Marp CLI to [v0.14.1](https://github.com/marp-team/marp-cli/releases/v0.14.1) ([#70](https://github.com/marp-team/marp-vscode/pull/70))
+- Disable style minification on preview ([#71](https://github.com/marp-team/marp-vscode/pull/71))
 
 ## v0.9.0 - 2019-08-28
 

--- a/src/option.ts
+++ b/src/option.ts
@@ -57,6 +57,7 @@ export const marpCoreOptionForPreview = (
       dollarPrefixForGlobalDirectives: true,
       html: marpConfiguration().get<boolean>('enableHtml') || undefined,
       markdown: { breaks: breaks(!!baseOption.breaks) },
+      minifyCSS: false,
     }
   }
   return cachedPreviewOption


### PR DESCRIPTION
Marp Core's style minification added by https://github.com/marp-team/marp-core/pull/103 is good for exported HTML. However, it has a bit of performance hit.

In preview pane, `minifyCSS: false` makes faster rendering and easier debug of style.