### PR TITLE
Update CircleCI configuration to use v2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,39 +1,65 @@
-references:
-  base: &base
+version: 2.1
+
+executors:
+  node:
+    parameters:
+      version:
+        type: string
+        default: lts
     docker:
-      - image: circleci/node:10.16.0
+      - image: circleci/node:<< parameters.version >>
     working_directory: ~/marp-vscode
+
+commands:
+  install:
+    parameters:
+      postinstall:
+        type: steps
+        default: []
+      yarn:
+        type: string
+        default: 1.17.3
     steps:
       # https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#upgradingdowngrading-yarn
       - run:
           name: Upgrade yarn
           command: |
             sudo -E sh -c 'curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
-                           && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
-                           && ln -snf /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
-                           && ln -snf /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
-                           && rm yarn-v$YARN_VERSION.tar.gz'
+              && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+              && ln -snf /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+              && ln -snf /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+              && rm yarn-v$YARN_VERSION.tar.gz'
           environment:
-            YARN_VERSION: 1.16.0
-
-      - checkout
+            YARN_VERSION: << parameters.yarn >>
 
       - restore_cache:
           keys:
-            - dependencies-{{ .Environment.CI_CACHE_KEY }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-{{ .Branch }}
-            - dependencies-{{ .Environment.CI_CACHE_KEY }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-
-            - dependencies-{{ .Environment.CI_CACHE_KEY }}-{{ .Environment.CIRCLE_JOB }}-
+            - v2.1-dependencies-{{ .Environment.CI_CACHE_KEY }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-{{ .Branch }}
+            - v2.1-dependencies-{{ .Environment.CI_CACHE_KEY }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-
+            - v2.1-dependencies-{{ .Environment.CI_CACHE_KEY }}-{{ .Environment.CIRCLE_JOB }}-
 
       - run: yarn install
-
-      # TODO: Use `yarn audit` to report audit of devDependencies
-      - run: yarn check:audit
+      - steps: << parameters.postinstall >>
 
       - save_cache:
-          key: dependencies-{{ .Environment.CI_CACHE_KEY }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-{{ .Branch }}
+          key: v2.1-dependencies-{{ .Environment.CI_CACHE_KEY }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "yarn.lock" }}-{{ .Branch }}
           paths:
             - node_modules
             - ~/.cache/yarn
+
+  audit:
+    steps:
+      - checkout
+      - install:
+          postinstall:
+            - run: yarn audit
+
+  test:
+    steps:
+      - run: node --version
+
+      - checkout
+      - install
 
       - run:
           name: Prettier formatting
@@ -52,10 +78,10 @@ references:
           command: yarn lint:css
 
       - run:
-          name: Unit test
+          name: Jest
           command: yarn test:unit:coverage --ci --maxWorkers=2 --reporters=default --reporters=jest-junit
           environment:
-            JEST_JUNIT_OUTPUT: tmp/test-results/jest.xml
+            JEST_JUNIT_OUTPUT_DIR: tmp/test-results
 
       - run: yarn codecov
 
@@ -66,36 +92,33 @@ references:
           path: ./coverage
           destination: coverage
 
-version: 2
 jobs:
-  electron3:
-    <<: *base
-    docker:
-      - image: circleci/node:10.2.0
-
-  electron4:
-    <<: *base
-    docker:
-      - image: circleci/node:10.11.0
-
-  github-release:
-    <<: *base
+  audit:
+    executor: node
     steps:
-      - checkout
-      - run:
-          name: Create release on GitHub
-          command: curl https://raw.githubusercontent.com/marp-team/marp/master/github-release.js | node
+      - audit
+
+  unit-electron3:
+    executor:
+      name: node
+      version: '10.2.0'
+    steps:
+      - test
+
+  unit-electron4:
+    executor:
+      name: node
+      version: '10.11.0'
+    steps:
+      - test
 
 workflows:
-  version: 2
-  build:
+  test:
     jobs:
-      - electron3
-      - electron4
-      - github-release:
-          context: github-release
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
+      - audit
+      - unit-electron3:
+          requires:
+            - audit
+      - unit-electron4:
+          requires:
+            - audit

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,16 @@
+name: GitHub Release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  github-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: marp-team/actions@v1
+        with:
+          task: release
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Upgrade Marp Core to [v0.13.1](https://github.com/marp-team/marp-core/releases/v0.13.1) and Marp CLI to [v0.14.1](https://github.com/marp-team/marp-cli/releases/v0.14.1) ([#70](https://github.com/marp-team/marp-vscode/pull/70))
+- Update CircleCI configuration to use v2.1 ([#72](https://github.com/marp-team/marp-vscode/pull/72))
 
 ## v0.9.0 - 2019-08-28
 

--- a/package.json
+++ b/package.json
@@ -201,7 +201,7 @@
     "preversion": "run-p check:* lint:* test:*:coverage",
     "test:unit": "jest",
     "test:unit:coverage": "jest --coverage",
-    "version": "curl https://raw.githubusercontent.com/marp-team/marp/master/version.js | node && git add -A CHANGELOG.md",
+    "version": "curl https://raw.githubusercontent.com/marp-team/actions/v1/lib/scripts/version.js | node && git add -A CHANGELOG.md",
     "vsce:publish": "npx vsce publish",
     "vscode:prepublish": "run-s preversion build",
     "watch": "rollup -w -c ./rollup.config.js"

--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
     "codecov": "^3.5.0",
     "dedent": "^0.7.0",
     "jest": "^24.9.0",
-    "jest-junit": "^7.0.0",
+    "jest-junit": "^8.0.0",
     "lodash.debounce": "^4.0.8",
     "markdown-it": "^10.0.0",
     "nanoid": "^2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3185,10 +3185,10 @@ jest-jasmine2@^24.9.0:
     pretty-format "^24.9.0"
     throat "^4.0.0"
 
-jest-junit@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-7.0.0.tgz#e2ab2dc3f4eb2768f3e4c43e4e4cd841133a8c0e"
-  integrity sha512-ljUdO0hLyu0A92xk7R2Wet3kj99fmazTo+ZFYQP6b7AGOBxJUj8ZkJWzJ632ajpXko2Y5oNoGR2kvOwiDdu6hg==
+jest-junit@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-8.0.0.tgz#d4f7ff67e292a5426dc60bc38694c9f77cb94178"
+  integrity sha512-cuD2XM2youMjrOxOu/7H2pLfsO8LfAG4D3WsBxd9fFyI9U0uPpmr/CORH64kbIyZ47X5x1Rbzb9ovUkAEvhEEA==
   dependencies:
     jest-validate "^24.0.0"
     mkdirp "^0.5.1"


### PR DESCRIPTION
CircleCI will run on v2.1. A new configuration has some maintainable commands (`install`, `test`, `audit`).

This change is same as [Marpit](https://github.com/marp-team/marpit/pull/187), [Marp Core](https://github.com/marp-team/marp-core/pull/101), and [Marp CLI](https://github.com/marp-team/marp-cli/pull/144).
