### PR TITLE
Fix style initialization for elements in VS Code preview pane

### DIFF
--- a/style.css
+++ b/style.css
@@ -3,25 +3,25 @@
 }
 
 /* Override VS Code default CSS rules reverting to initial
-   https://github.com/Microsoft/vscode/blob/master/src/vs/workbench/contrib/webview/electron-browser/webview-pre.js#L412 */
+   https://github.com/microsoft/vscode/blob/master/src/vs/workbench/contrib/webview/browser/pre/main.js#L53 */
 body.marp-vscode {
   padding: 0;
 }
 
 body.marp-vscode img {
-  max-width: initial;
-  max-height: initial;
+  max-width: unset;
+  max-height: unset;
 }
 
 body.marp-vscode a,
 body.marp-vscode a:hover,
 body.marp-vscode code {
-  color: initial;
+  color: unset;
 }
 
 body.marp-vscode blockquote {
-  background: initial;
-  border-color: initial;
+  background: unset;
+  border-color: unset;
 }
 
 @media screen {

--- a/style.css
+++ b/style.css
@@ -40,7 +40,7 @@ body.marp-vscode blockquote {
     overflow: visible;
   }
 
-  /* from https://github.com/Microsoft/vscode-docs-authoring/blob/master/docs-preview/media/markdown.css */
+  /* Based on https://github.com/microsoft/vscode/blob/master/extensions/markdown-language-features/media/markdown.css */
   #code-csp-warning {
     background-color: #444;
     box-shadow: 1px 1px 1px rgba(0, 0, 0, 0.25);


### PR DESCRIPTION
A way to reset VS Code's default style by using `initial` was not better because it would break some theme styles such as #74.

`initial` indicates that will prefer browser's default value, so the global style for element will ignore if specified. To avoid this behavior, we can use `unset` value.

Fix #74.

|Previous|:arrow_forward:|After|
|:---:|:---:|:---:|
|<img src="https://user-images.githubusercontent.com/3993388/65004933-23e3b680-d939-11e9-9ad1-a098db08486f.png" width="500" />|:arrow_forward:|<img width="500" src="https://user-images.githubusercontent.com/3993388/65008431-52b35a00-d944-11e9-97fa-1ed5534628fc.png"/>|
