### PR TITLE
Update community health files

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,12 +2,7 @@
 
 Thank you for taking the time to read how to contribute to Marp for VS Code! This is the guideline for contributing to Marp for VS Code.
 
-We are following [the contributing guideline of marp-team projects](https://github.com/marp-team/marp/blob/master/.github/CONTRIBUTING.md). Please read these guidelines this before starting work in Marp for VS Code.
-
-- [**Code of Conduct**](https://github.com/marp-team/marp/blob/master/.github/CODE_OF_CONDUCT.md)
-- [**Report issue**](https://github.com/marp-team/marp/blob/master/.github/CONTRIBUTING.md#report-issue)
-- [**Pull request**](https://github.com/marp-team/marp/blob/master/.github/CONTRIBUTING.md#pull-request)
-- [**Release**](https://github.com/marp-team/marp/blob/master/.github/CONTRIBUTING.md#release)
+We are following [**the contributing guideline of Marp team projects**](https://github.com/marp-team/.github/blob/master/CONTRIBUTING.md). _You have to read this before starting work._
 
 ## Development
 
@@ -43,4 +38,4 @@ yarn package
 
 A way to release is different from other projects of Marp Team targeted to npm.
 
-Just run `yarn vsce:publish [major|minor|patch]` at the latest `master` branch. It can [bump version](https://github.com/marp-team/marp/blob/master/.github/CONTRIBUTING.md#bump-version) and release to Marketplace at once. Don't forget `git push && git push --tags`!
+Just run `yarn vsce:publish [major|minor|patch]` at the latest `master` branch. It can [bump version](https://github.com/marp-team/.github/blob/master/CONTRIBUTING.md#bump-version) and release to Marketplace at once. Don't forget `git push && git push --tags`!

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: [yhatt]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Update community health files ([#107](https://github.com/marp-team/marp-vscode/pull/107))
+
 ## v0.11.2 - 2019-11-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ You can enable previsualization of HTML code within Marp Markdown with the `mark
 
 ## Contributing
 
-Are you interested in contributing? Please see [CONTRIBUTING.md](.github/CONTRIBUTING.md).
+Are you interested in contributing? Please see [CONTRIBUTING.md](.github/CONTRIBUTING.md) and [the common contributing guideline for Marp team](https://github.com/marp-team/.github/blob/master/CONTRIBUTING.md).
 
 ## Author
 


### PR DESCRIPTION
Marp team's common health files such as CONTRIBUTING.md were moved to [`.github` repository](https://github.com/marp-team/.github).
