### PR TITLE
Add option for using a custom Marp CLI config

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
         "markdown.marp.customConfig": {
           "type": "boolean",
           "default": false,
-          "description": "Use Marp CLI config files in workspace folders, if they exist."
+          "description": "Enable using a custom Marp CLI config file for exporting (does not affect preview in VS Code). Custom config file must be placed in the root of the workspace."
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -126,6 +126,11 @@
           "type": "boolean",
           "default": true,
           "description": "Shows editor toolbar button to Markdown document, for accessing quick pick of Marp commands."
+        },
+        "markdown.marp.customConfig": {
+          "type": "boolean",
+          "default": false,
+          "description": "Use Marp CLI config files in workspace folders, if they exist."
         }
       }
     },

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -37,9 +37,8 @@ export const doExport = async (uri: Uri, document: TextDocument) => {
   const input = await createWorkFile(document)
 
   try {
-    
     const conf = await createConfigFile(document)
-    
+
     try {
       if (!const marpConfiguration().get<boolean>('customConfig')){
         await marpCli('-c', conf.path, input.path, '-o', uri.fsPath)

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -40,7 +40,7 @@ export const doExport = async (uri: Uri, document: TextDocument) => {
     const conf = await createConfigFile(document)
 
     try {
-      if (!const marpConfiguration().get<boolean>('customConfig')){
+      if (!marpConfiguration().get<boolean>('customConfig')) {
         await marpCli('-c', conf.path, input.path, '-o', uri.fsPath)
       } else {
         /* If we  are using the custom config, set the working directory

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -37,8 +37,22 @@ export const doExport = async (uri: Uri, document: TextDocument) => {
   const input = await createWorkFile(document)
 
   try {
-    const conf = await createConfigFile(document)
-
+    /*Check options to determine whether or not to use a custom config*/
+    try {
+      if (const marpConfiguration().get<boolean>('customConfig')){
+        const conf = await loadConfigFile(XXX)
+      } else {
+        const conf = await createConfigFile(document)
+      }
+    } catch (e) {
+      /*${workspace().path}*/
+      console.error(
+        `Failed to load custom config file from "XXX". (${e.message})`
+      )
+    } finally {
+      const conf = await createConfigFile(document)
+    }
+    
     try {
       await marpCli('-c', conf.path, input.path, '-o', uri.fsPath)
       env.openExternal(uri)

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -40,14 +40,14 @@ export const doExport = async (uri: Uri, document: TextDocument) => {
     /*Check options to determine whether or not to use a custom config*/
     try {
       if (const marpConfiguration().get<boolean>('customConfig')){
-        const conf = await loadConfigFile(XXX)
+        const conf = await loadConfigFile(document)
       } else {
         const conf = await createConfigFile(document)
       }
     } catch (e) {
       /*${workspace().path}*/
       console.error(
-        `Failed to load custom config file from "XXX". (${e.message})`
+        `Error loading custom configurations; falling back on default config. (${e.message})`
       )
     } finally {
       const conf = await createConfigFile(document)

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -77,40 +77,6 @@ export async function createConfigFile(
   }
 }
 
-export async function loadConfigFile(
-  target: TextDocument
-): Promise<WorkFile> {
-  const tmpFileName = `.marp-vscode-cli-conf-${nanoid()}.json`
-  const tmpPath = path.join(tmpdir(), tmpFileName)
-  const cliOpts = await marpCoreOptionForCLI(target)
-
-  /* Find config file (needs a bit more logic to check for the other
-   * types of config files)
-   */
-  const documentWorkspace = workspace.getWorkspaceFolder(doc.uri)
-  const configFileName = path.join(documentWorkspace.uri.fsPath, '.marprc')
-  
-  /* Proposed implementation:
-   *
-   * 1. Load config file as a dictionary (JSON object?), e.g. `tmpConfig`
-   * 2. Iterate over keys in `tmpConfig` and insert (or replace) the key:value in `cliOpts`
-   *
-   * Advantage here is that the user only has to replace the options that they care to modify.
-   * This is useful because specifying where you should look for themes is potentially painful.
-   */
-  await promiseWriteFile(tmpPath, JSON.stringify(cliOpts))
-
-  return {
-    path: tmpPath,
-    cleanup: async () => {
-      await Promise.all([
-        promiseUnlink(tmpPath),
-        ...cliOpts.vscode.themeFiles.map((w: WorkFile) => w.cleanup()),
-      ])
-    },
-  }
-}
-
 export default async function runMarpCli(...opts: string[]): Promise<void> {
   const argv = ['--no-stdin', ...opts]
   console.info(`Execute Marp CLI: ${argv.join(' ')}`)

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -84,6 +84,20 @@ export async function loadConfigFile(
   const tmpPath = path.join(tmpdir(), tmpFileName)
   const cliOpts = await marpCoreOptionForCLI(target)
 
+  /* Find config file (needs a bit more logic to check for the other
+   * types of config files)
+   */
+  const documentWorkspace = workspace.getWorkspaceFolder(doc.uri)
+  const configFileName = path.join(documentWorkspace.uri.fsPath, '.marprc')
+  
+  /* Proposed implementation:
+   *
+   * 1. Load config file as a dictionary (JSON object?), e.g. `tmpConfig`
+   * 2. Iterate over keys in `tmpConfig` and insert (or replace) the key:value in `cliOpts`
+   *
+   * Advantage here is that the user only has to replace the options that they care to modify.
+   * This is useful because specifying where you should look for themes is potentially painful.
+   */
   await promiseWriteFile(tmpPath, JSON.stringify(cliOpts))
 
   return {

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -77,6 +77,26 @@ export async function createConfigFile(
   }
 }
 
+export async function loadConfigFile(
+  target: TextDocument
+): Promise<WorkFile> {
+  const tmpFileName = `.marp-vscode-cli-conf-${nanoid()}.json`
+  const tmpPath = path.join(tmpdir(), tmpFileName)
+  const cliOpts = await marpCoreOptionForCLI(target)
+
+  await promiseWriteFile(tmpPath, JSON.stringify(cliOpts))
+
+  return {
+    path: tmpPath,
+    cleanup: async () => {
+      await Promise.all([
+        promiseUnlink(tmpPath),
+        ...cliOpts.vscode.themeFiles.map((w: WorkFile) => w.cleanup()),
+      ])
+    },
+  }
+}
+
 export default async function runMarpCli(...opts: string[]): Promise<void> {
   const argv = ['--no-stdin', ...opts]
   console.info(`Execute Marp CLI: ${argv.join(' ')}`)


### PR DESCRIPTION
# Proposal

Allow marp-vscode power users to take advantage of all features (current and future) in Marp CLI by allowing them to specify a custom config file (instead of using the default config provided by marp-vscode). 

If this option is specified, the output may be different than the version seen in vscode's markdown preview. This is why the option will be by default turned off.

Related to: #85, #86, #121
   
# Steps

- [x] Add an option in vscode to toggle the option `customConfig`
    - [x] Default should be false
~~- [ ] Write logic to load custom config~~
~~- [ ] Search for default config filenames in the root of the workspace directory (e.g., `.marprc`, `marp.config.js`~~
~~- [ ] Load the configurations and add/overwrite the default config~~
- [x] Check `customConfig` option when exporting to file to determine whether to create a default config or load a custom config
  - [x] Allow marp cli to search markdown document's path
 ~~- [x] Fall-back on creating a custom config~~



