### PR TITLE
Drop support for VS Code < 1.40

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,19 +18,11 @@ commands:
         default: []
       yarn:
         type: string
-        default: 1.22.0
+        default: 1.22.4
     steps:
-      # https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#upgradingdowngrading-yarn
       - run:
-          name: Upgrade yarn
-          command: |
-            sudo -E sh -c 'curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
-              && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
-              && ln -snf /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
-              && ln -snf /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
-              && rm yarn-v$YARN_VERSION.tar.gz'
-          environment:
-            YARN_VERSION: << parameters.yarn >>
+          name: Upgrade yarn for current user
+          command: cd ~ && yarn policies set-version << parameters.yarn >>
 
       - restore_cache:
           keys:
@@ -97,16 +89,6 @@ jobs:
     steps:
       - audit
 
-  unit-electron4:
-    executor:
-      name: node
-
-      # Electron 4 is using Node 10.11.0, but we have to run test with Node
-      # >= 10.14.2 due to https://github.com/facebook/jest/issues/9453.
-      version: '10.14.2'
-    steps:
-      - test
-
   unit-electron6:
     executor:
       name: node
@@ -118,9 +100,6 @@ workflows:
   test:
     jobs:
       - audit
-      - unit-electron4:
-          requires:
-            - audit
       - unit-electron6:
           requires:
             - audit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,10 +96,20 @@ jobs:
     steps:
       - test
 
+  unit-electron7:
+    executor:
+      name: node
+      version: '12.8.1'
+    steps:
+      - test
+
 workflows:
   test:
     jobs:
       - audit
       - unit-electron6:
+          requires:
+            - audit
+      - unit-electron7:
           requires:
             - audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Breaking
+
+- VS Code >= 1.40 ([Electron >= 6](https://code.visualstudio.com/updates/v1_40#_electron-60-update)) is now required ([#138](https://github.com/marp-team/marp-vscode/pull/138))
+
 ### Changed
 
 - Upgrade to [Marp Core v1.1.0](https://github.com/marp-team/marp-core/releases/v1.1.0) and [Marp CLI v0.17.3](https://github.com/marp-team/marp-cli/releases/v0.17.3) ([#130](https://github.com/marp-team/marp-vscode/pull/130))

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/marp-team/marp-vscode"
   },
   "engines": {
-    "vscode": "^1.36.0"
+    "vscode": "^1.40.0"
   },
   "main": "./lib/extension.js",
   "icon": "images/icon.png",
@@ -215,7 +215,7 @@
     "@types/jest": "^25.2.1",
     "@types/lodash.debounce": "^4.0.6",
     "@types/markdown-it": "^10.0.0",
-    "@types/vscode": "~1.36.0",
+    "@types/vscode": "~1.40.0",
     "@types/yaml": "^1.2.0",
     "builtin-modules": "^3.1.0",
     "cheerio": "^1.0.0-rc.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -796,10 +796,10 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
-"@types/vscode@~1.36.0":
-  version "1.36.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.36.0.tgz#ae60242e893d9eda9a0d96d51ef56f1a3fae14ed"
-  integrity sha512-SbHR3Q5g/C3N+Ila3KrRf1rSZiyHxWdOZ7X3yFHXzw6HrvRLuVZrxnwEX0lTBMRpH9LkwZdqRTgXW+D075jxkg==
+"@types/vscode@~1.40.0":
+  version "1.40.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.40.0.tgz#47d19e9e32da512c986f579fe6afbc8d3e6e0c55"
+  integrity sha512-5kEIxL3qVRkwhlMerxO7XuMffa+0LBl+iG2TcRa0NsdoeSFLkt/9hJ02jsi/Kvc6y8OVF2N2P2IHP5S4lWf/5w==
 
 "@types/yaml@^1.2.0":
   version "1.2.0"


### PR DESCRIPTION
Puppeteer v3 in the bumped Marp CLI is not compatible with Node v10.11.0 using in Electron 4. To keep dependencies to the latest, we have to drop the support for VS Code < v1.40.

I also added test against Node 12.8.1, is used in Electron 7 / VS Code >= 1.43.

> NOTE: The current VS Code version is v1.44. VS Code has auto-updation into the latest version, and we can't think that there are stuck users in the previous version.