### PR TITLE
Add markdown.marp.mathTypesetting configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add `markdown.marp.mathTypesetting` configuration to control math typesetting library for Marp Core's math plugin ([#145](https://github.com/marp-team/marp-vscode/issues/145), [#148](https://github.com/marp-team/marp-vscode/pull/148))
+
 ### Changed
 
 - Upgrade to [Marp Core v1.2.0](https://github.com/marp-team/marp-core/releases/v1.2.0) and [Marp CLI v0.18.1](https://github.com/marp-team/marp-cli/releases/v0.18.1) ([#147](https://github.com/marp-team/marp-vscode/pull/147))

--- a/package.json
+++ b/package.json
@@ -114,6 +114,19 @@
             "JPEG image (first slide only)"
           ]
         },
+        "markdown.marp.mathTypesetting": {
+          "type": "string",
+          "enum": [
+            "mathjax",
+            "katex"
+          ],
+          "default": "katex",
+          "markdownDescription": "Controls math typesetting library for rendering [Marp Core](https://github.com/marp-team/marp-core)'s math syntax in Marp Markdown.",
+          "markdownEnumDescriptions": [
+            "MathJax (https://www.mathjax.org/)",
+            "KaTeX (https://katex.org/): The default library in Marp Core"
+          ]
+        },
         "markdown.marp.themes": {
           "type": "array",
           "default": [],

--- a/package.json
+++ b/package.json
@@ -79,10 +79,10 @@
           ],
           "default": "on",
           "description": "Sets how line-breaks are rendered in Marp Markdown. It can set separately because the default setting of Marp ecosystem is different from VS Code.",
-          "enumDescriptions": [
+          "markdownEnumDescriptions": [
             "Ignore line-breaks in rendered Marp Markdown preview.",
             "Show line-breaks in rendered Marp Markdown preview. It is the default setting of Marp ecosystem.",
-            "Use inherited setting from markdown.preview.breaks."
+            "Use inherited setting from `markdown.preview.breaks`."
           ]
         },
         "markdown.marp.chromePath": {
@@ -121,7 +121,7 @@
             "katex"
           ],
           "default": "katex",
-          "markdownDescription": "Controls math typesetting library for rendering [Marp Core](https://github.com/marp-team/marp-core)'s math syntax in Marp Markdown.",
+          "markdownDescription": "Controls math typesetting library for rendering math syntax by [Marp Core](https://github.com/marp-team/marp-core).",
           "markdownEnumDescriptions": [
             "MathJax (https://www.mathjax.org/)",
             "KaTeX (https://katex.org/): The default library in Marp Core"

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -184,6 +184,24 @@ describe('#extendMarkdownIt', () => {
       })
     })
 
+    describe('markdown.marp.mathTypesetting', () => {
+      it('renders math syntax in KaTeX when setting "katex"', () => {
+        setConfiguration({ 'markdown.marp.mathTypesetting': 'katex' })
+
+        const html = md().render(marpMd('$a=b$'))
+        expect(html).toContain('katex')
+        expect(html).not.toContain('MathJax')
+      })
+
+      it('renders math syntax in MathJax when setting "mathjax"', () => {
+        setConfiguration({ 'markdown.marp.mathTypesetting': 'mathjax' })
+
+        const html = md().render(marpMd('$a=b$'))
+        expect(html).not.toContain('katex')
+        expect(html).toContain('MathJax')
+      })
+    })
+
     describe('markdown.marp.themes', () => {
       const baseDir = '/test/path'
       const css = '/* @theme example */'

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,7 @@ import { detectMarpFromMarkdown } from './utils'
 const shouldRefreshConfs = [
   'markdown.marp.breaks',
   'markdown.marp.enableHtml',
+  'markdown.marp.mathTypesetting',
   'markdown.marp.themes',
   'markdown.preview.breaks',
 ]

--- a/src/option.ts
+++ b/src/option.ts
@@ -35,6 +35,7 @@ export const marpCoreOptionForPreview = (
       container: { tag: 'div', id: 'marp-vscode' },
       html: marpConfiguration().get<boolean>('enableHtml') || undefined,
       markdown: { breaks: breaks(!!baseOption.breaks) },
+      math: marpConfiguration().get<'katex' | 'mathjax'>('mathTypesetting'),
       minifyCSS: false,
       script: false,
     }
@@ -54,6 +55,7 @@ export const marpCoreOptionForCLI = async ({ uri }: TextDocument) => {
             .get<boolean>('breaks')
         ),
       },
+      math: marpConfiguration().get<'katex' | 'mathjax'>('mathTypesetting'),
     },
     themeSet: [] as string[],
     vscode: {} as Record<string, any>,


### PR DESCRIPTION
The added `markdown.marp.mathTypesetting` configuration can control math typesetting library for math plugin in [Marp Core v1.2.0](https://github.com/marp-team/marp-core/releases/tag/v1.2.0) (Updated in #147): `mathjax` and `katex` (default).

MathJax has more compatibility with TeX than KaTeX, the default library in Marp Core. However, it may make slow conversion of Markdown if there are a lot of math syntaxes.