### PR TITLE
Drop support for VS Code < 1.43

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,13 +89,6 @@ jobs:
     steps:
       - audit
 
-  unit-electron6:
-    executor:
-      name: node
-      version: '12.4.0'
-    steps:
-      - test
-
   unit-electron7:
     executor:
       name: node
@@ -107,9 +100,6 @@ workflows:
   test:
     jobs:
       - audit
-      - unit-electron6:
-          requires:
-            - audit
       - unit-electron7:
           requires:
             - audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Breaking
+
+- VS Code >= 1.43 ([Electron 7](https://code.visualstudio.com/updates/v1_43#_electron-70-update)) is now required ([#154](https://github.com/marp-team/marp-vscode/pull/154))
+
 ### Changed
 
 - Upgrade to [Marp Core v1.2.2](https://github.com/marp-team/marp-core/releases/v1.2.2) and [Marp CLI v0.20.0](https://github.com/marp-team/marp-cli/releases/v0.20.0) ([#151](https://github.com/marp-team/marp-vscode/pull/151))

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/marp-team/marp-vscode"
   },
   "engines": {
-    "vscode": "^1.40.0"
+    "vscode": "^1.42.0"
   },
   "main": "./lib/extension.js",
   "icon": "images/icon.png",
@@ -226,7 +226,7 @@
     "@types/jest": "^26.0.7",
     "@types/lodash.debounce": "^4.0.6",
     "@types/markdown-it": "^10.0.1",
-    "@types/vscode": "~1.40.0",
+    "@types/vscode": "~1.42.0",
     "@types/yaml": "^1.9.7",
     "builtin-modules": "^3.1.0",
     "codecov": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/marp-team/marp-vscode"
   },
   "engines": {
-    "vscode": "^1.42.0"
+    "vscode": "^1.43.0"
   },
   "main": "./lib/extension.js",
   "icon": "images/icon.png",
@@ -226,7 +226,7 @@
     "@types/jest": "^26.0.7",
     "@types/lodash.debounce": "^4.0.6",
     "@types/markdown-it": "^10.0.1",
-    "@types/vscode": "~1.42.0",
+    "@types/vscode": "~1.43.0",
     "@types/yaml": "^1.9.7",
     "builtin-modules": "^3.1.0",
     "codecov": "^3.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -804,10 +804,10 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
-"@types/vscode@~1.42.0":
-  version "1.42.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.42.0.tgz#0ad891a9487e91e34be7c56985058a179031eb76"
-  integrity sha512-ds6TceMsh77Fs0Mq0Vap6Y72JbGWB8Bay4DrnJlf5d9ui2RSe1wis13oQm+XhguOeH1HUfLGzaDAoupTUtgabw==
+"@types/vscode@~1.43.0":
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.43.0.tgz#22276e60034c693b33117f1068ffaac0e89522db"
+  integrity sha512-kIaR9qzd80rJOxePKpCB/mdy00mz8Apt2QA5Y6rdrKFn13QNFNeP3Hzmsf37Bwh/3cS7QjtAeGSK7wSqAU0sYQ==
 
 "@types/yaml@^1.9.7":
   version "1.9.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -804,10 +804,10 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==
 
-"@types/vscode@~1.40.0":
-  version "1.40.0"
-  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.40.0.tgz#47d19e9e32da512c986f579fe6afbc8d3e6e0c55"
-  integrity sha512-5kEIxL3qVRkwhlMerxO7XuMffa+0LBl+iG2TcRa0NsdoeSFLkt/9hJ02jsi/Kvc6y8OVF2N2P2IHP5S4lWf/5w==
+"@types/vscode@~1.42.0":
+  version "1.42.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.42.0.tgz#0ad891a9487e91e34be7c56985058a179031eb76"
+  integrity sha512-ds6TceMsh77Fs0Mq0Vap6Y72JbGWB8Bay4DrnJlf5d9ui2RSe1wis13oQm+XhguOeH1HUfLGzaDAoupTUtgabw==
 
 "@types/yaml@^1.9.7":
   version "1.9.7"


### PR DESCRIPTION
Marp for VS Code is now required VS Code >= 1.43 (Electron 7). It can use some API updates (e.g. Codicon to improve discoverability).

> NOTE: The current VS Code version is v1.47. VS Code has auto-updation into the latest version, and we can't think that there are stuck users in the previous version.