### PR TITLE
Open extension settings from quick pick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - VS Code >= 1.43 ([Electron 7](https://code.visualstudio.com/updates/v1_43#_electron-70-update)) is now required ([#154](https://github.com/marp-team/marp-vscode/pull/154))
 
+### Added
+
+- Open extension settings from quick pick ([#155](https://github.com/marp-team/marp-vscode/pull/155))
+
 ### Changed
 
 - Upgrade to [Marp Core v1.2.2](https://github.com/marp-team/marp-core/releases/v1.2.2) and [Marp CLI v0.20.0](https://github.com/marp-team/marp-cli/releases/v0.20.0) ([#151](https://github.com/marp-team/marp-vscode/pull/151))

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
           "markdownEnumDescriptions": [
             "Ignore line-breaks in rendered Marp Markdown preview.",
             "Show line-breaks in rendered Marp Markdown preview. It is the default setting of Marp ecosystem.",
-            "Use inherited setting from `markdown.preview.breaks`."
+            "Use inherited setting from `#markdown.preview.breaks#`."
           ]
         },
         "markdown.marp.chromePath": {
@@ -130,7 +130,7 @@
         "markdown.marp.themes": {
           "type": "array",
           "default": [],
-          "markdownDescription": "A list of URLs or local paths to additional [theme CSS](https://marpit.marp.app/theme-css) for Marp core and Marpit framework. The rule for paths is following [Markdown: Styles](#markdown.styles).",
+          "markdownDescription": "A list of URLs or local paths to additional [theme CSS](https://marpit.marp.app/theme-css) for Marp core and Marpit framework. The rule for paths is following `#markdown.styles#`.",
           "items": {
             "type": "string"
           }

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -33,6 +33,8 @@ const descriptions = {
 
 export const ITEM_CONTINUE_TO_EXPORT = 'Continue to export...'
 
+export const command = 'markdown.marp.export'
+
 export const doExport = async (uri: Uri, document: TextDocument) => {
   const input = await createWorkFile(document)
 

--- a/src/commands/open-extension-settings.test.ts
+++ b/src/commands/open-extension-settings.test.ts
@@ -1,0 +1,15 @@
+import { commands } from 'vscode'
+import openExtensionSettings from './open-extension-settings'
+
+jest.mock('vscode')
+
+describe('openExtensionSettings command', () => {
+  it('executes "workbench.action.openSettings" command with filter for Marp extension', async () => {
+    await openExtensionSettings()
+
+    expect(commands.executeCommand).toBeCalledWith(
+      'workbench.action.openSettings',
+      '@ext:marp-team.marp-vscode'
+    )
+  })
+})

--- a/src/commands/open-extension-settings.ts
+++ b/src/commands/open-extension-settings.ts
@@ -1,0 +1,11 @@
+import { commands } from 'vscode'
+import { publisher, name } from '../../package.json'
+
+export const command = 'markdown.marp.openExtensionSettings'
+
+export default async function openExtensionSettings() {
+  await commands.executeCommand(
+    'workbench.action.openSettings',
+    `@ext:${publisher}.${name}`
+  )
+}

--- a/src/commands/show-quick-pick.test.ts
+++ b/src/commands/show-quick-pick.test.ts
@@ -1,13 +1,13 @@
-import { commands, window, QuickPickItem } from 'vscode'
-import showQuickPick from './show-quick-pick'
+import { commands, window } from 'vscode'
+import showQuickPick, { cmdSymbol } from './show-quick-pick'
 
 jest.mock('vscode')
 
 describe('showQuickPick command', () => {
   it('shows quick pick for Marp command', async () => {
-    const expectedItem: QuickPickItem = {
+    const expectedItem = {
       label: expect.any(String),
-      description: expect.stringMatching(/^markdown\.marp/),
+      [cmdSymbol]: expect.stringMatching(/^markdown\.marp/),
     }
 
     await showQuickPick()
@@ -20,8 +20,8 @@ describe('showQuickPick command', () => {
   it('executes command if selected item has description', async () => {
     jest.spyOn(window, 'showQuickPick').mockResolvedValue({
       label: 'Example command',
-      description: 'example.command',
-    })
+      [cmdSymbol]: 'example.command',
+    } as any)
 
     await showQuickPick()
     expect(commands.executeCommand).toBeCalledWith('example.command')

--- a/src/commands/show-quick-pick.ts
+++ b/src/commands/show-quick-pick.ts
@@ -1,16 +1,31 @@
 import { commands, QuickPickItem, window } from 'vscode'
 import { contributes } from '../../package.json'
+import { command as exportCommand } from './export'
+import { command as toggleMarpPreviewCommand } from './toggle-marp-preview'
+import { command as openExtensionSettingsCommand } from './open-extension-settings'
 
-const availableCommands: QuickPickItem[] = []
+const cmdSymbol = Symbol()
+const contributedCommands = [exportCommand, toggleMarpPreviewCommand]
+const availableCommands: (QuickPickItem & { [cmdSymbol]: string })[] = []
 
-for (const command of contributes.commands) {
-  if (command.command === 'markdown.marp.showQuickPick') continue
+for (const cmdPath of contributedCommands) {
+  const cmd = contributes.commands.find(({ command }) => cmdPath === command)
 
-  availableCommands.push({
-    label: command.title,
-    description: command.command,
-  })
+  if (cmd) {
+    availableCommands.push({
+      [cmdSymbol]: cmdPath,
+      description: cmdPath,
+      label: cmd.title,
+    })
+  }
 }
+
+availableCommands.push({
+  label: '$(settings-gear) Open extension settings',
+  [cmdSymbol]: openExtensionSettingsCommand,
+})
+
+export const command = 'markdown.marp.showQuickPick'
 
 export default async function showQuickPick() {
   const command = await window.showQuickPick(availableCommands, {
@@ -18,5 +33,7 @@ export default async function showQuickPick() {
     placeHolder: 'Select available command in Marp for VS Code...',
   })
 
-  if (command?.description) await commands.executeCommand(command.description)
+  if (command?.[cmdSymbol]) {
+    await commands.executeCommand(command[cmdSymbol])
+  }
 }

--- a/src/commands/show-quick-pick.ts
+++ b/src/commands/show-quick-pick.ts
@@ -4,7 +4,8 @@ import { command as exportCommand } from './export'
 import { command as toggleMarpPreviewCommand } from './toggle-marp-preview'
 import { command as openExtensionSettingsCommand } from './open-extension-settings'
 
-const cmdSymbol = Symbol()
+export const cmdSymbol = Symbol()
+
 const contributedCommands = [exportCommand, toggleMarpPreviewCommand]
 const availableCommands: (QuickPickItem & { [cmdSymbol]: string })[] = []
 

--- a/src/commands/toggle-marp-preview.ts
+++ b/src/commands/toggle-marp-preview.ts
@@ -41,6 +41,8 @@ export const toggle = async (editor: TextEditor) => {
   }
 }
 
+export const command = 'markdown.marp.toggleMarpPreview'
+
 export default async function toggleMarpPreview() {
   const activeEditor = window.activeTextEditor
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,9 +1,10 @@
 import path from 'path'
 import { Marp } from '@marp-team/marp-core'
 import { ExtensionContext, Uri, commands, workspace } from 'vscode'
-import exportCommand from './commands/export' // tslint:disable-line: import-name
-import showQuickPick from './commands/show-quick-pick'
-import toggleMarpPreview from './commands/toggle-marp-preview'
+import * as exportCommand from './commands/export'
+import * as openExtensionSettings from './commands/open-extension-settings'
+import * as showQuickPick from './commands/show-quick-pick'
+import * as toggleMarpPreview from './commands/toggle-marp-preview'
 import customTheme from './plugins/custom-theme'
 import lineNumber from './plugins/line-number'
 import outline from './plugins/outline'
@@ -113,11 +114,15 @@ export const activate = ({ subscriptions }: ExtensionContext) => {
   diagnostics(subscriptions)
 
   subscriptions.push(
-    commands.registerCommand('markdown.marp.export', exportCommand),
-    commands.registerCommand('markdown.marp.showQuickPick', showQuickPick),
+    commands.registerCommand(exportCommand.command, exportCommand.default),
     commands.registerCommand(
-      'markdown.marp.toggleMarpPreview',
-      toggleMarpPreview
+      openExtensionSettings.command,
+      openExtensionSettings.default
+    ),
+    commands.registerCommand(showQuickPick.command, showQuickPick.default),
+    commands.registerCommand(
+      toggleMarpPreview.command,
+      toggleMarpPreview.default
     ),
     themes,
     workspace.onDidChangeConfiguration((e) => {


### PR DESCRIPTION
In spite of [the contribution for documentation from community](https://github.com/marp-team/marp-vscode/pull/99), we have recognized that there are still many marp-vscode users who don't know how to enable HTML.

I added `⚙ Open extension settings` into the quick pick to improve discoverability of settings for Marp.

![](https://user-images.githubusercontent.com/3993388/88451242-1ddf3000-ce90-11ea-9126-76a6d279c130.png)

It is already accessible by [`Extension Settings` in the context menu opened from extensions pane](https://user-images.githubusercontent.com/3993388/88451250-29325b80-ce90-11ea-8dc7-5781ae190bab.png), but an added quick pick item would be more discoverable how to access settings.

> An added `markdown.marp.openExtensionSettings` command is not accessible from Command Palette (<kbd>Ctrl/Cmd+Shift+P</kbd>) because an duplicated item [from the other context menu](https://user-images.githubusercontent.com/3993388/88451250-29325b80-ce90-11ea-8dc7-5781ae190bab.png) must not make a noise in the command list.