### PR TITLE
Add GitHub Actions workflow to upload packaged VSIX into release page

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -14,3 +14,31 @@ jobs:
         with:
           task: release
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  upload-vsix:
+    needs: github-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Detect Node version from .nvmrc
+        id: node_version
+        run: echo "::set-output name=nvmrc::$(cat .nvmrc)"
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ steps.node_version.outputs.nvmrc }}
+
+      - run: npm ci
+      - run: npm run package
+
+      - name: Find out created VSIX
+        id: vsix
+        run: echo "::set-output name=name::$(find . -maxdepth 1 -name '*.vsix' -printf '%f\n' | head -n 1)"
+
+      - name: Upload VSIX to GitHub Release
+        uses: marp-team/actions@v1
+        with:
+          task: upload
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: ${{ steps.vsix.outputs.name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- GitHub Actions workflow to upload packaged VSIX into release page ([#182](https://github.com/marp-team/marp-vscode/issues/182), [#188](https://github.com/marp-team/marp-vscode/pull/188))
+
 ### Changed
 
 - Upgrade to [Marp Core v1.4.0](https://github.com/marp-team/marp-core/releases/v1.4.0) ([#186](https://github.com/marp-team/marp-vscode/pull/186))


### PR DESCRIPTION
Added the workflow for automated VSIX packaging in GitHub Actions.

Please note a created package may be different from a package published to Visual Studio Marketplace because VSIX for marketplace is still uploading from local.

Close #182.