### PR TITLE
Make icons for editor action monochrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Upgrade to [Marp Core v1.4.1](https://github.com/marp-team/marp-core/releases/v1.4.1) and [Marp CLI v0.23.1](https://github.com/marp-team/marp-cli/releases/v0.23.1) ([#195](https://github.com/marp-team/marp-vscode/pull/195))
 - Upgrade dependent packages to the latest version ([#195](https://github.com/marp-team/marp-vscode/pull/195))
+- Make icons for editor action monochrome, to follow [VS Code extension guideline](https://code.visualstudio.com/api/references/extension-guidelines#editor-actions) ([#193](https://github.com/marp-team/marp-vscode/issues/193), [#196](https://github.com/marp-team/marp-vscode/pull/196))
 
 ## v0.17.0 - 2020-12-05
 

--- a/images/icon-dark.svg
+++ b/images/icon-dark.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M14 3l-3 3V4l-1-1-9 9 1 1h12l1-1V4zm-4 9H6.4L10 8.4zm0-5l-5 5H2.4L10 4.4zm4 5h-3V7.4l3-3z" fill="#67b8e3"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M14 3l-3 3V4l-1-1-9 9 1 1h12l1-1V4zm-4 9H6.4L10 8.4zm0-5l-5 5H2.4L10 4.4zm4 5h-3V7.4l3-3z" fill="#ccc"/></svg>

--- a/images/icon-light.svg
+++ b/images/icon-light.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M14 3l-3 3V4l-1-1-9 9 1 1h12l1-1V4zm-4 9H6.4L10 8.4zm0-5l-5 5H2.4L10 4.4zm4 5h-3V7.4l3-3z" fill="#0288d1"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M14 3l-3 3V4l-1-1-9 9 1 1h12l1-1V4zm-4 9H6.4L10 8.4zm0-5l-5 5H2.4L10 4.4zm4 5h-3V7.4l3-3z" fill="#616161"/></svg>


### PR DESCRIPTION
To follow VS Code extension guideline: https://code.visualstudio.com/api/references/extension-guidelines#editor-actions

![](https://user-images.githubusercontent.com/3993388/107136394-06f0be80-6946-11eb-9071-3ef540c71c79.png)
![](https://user-images.githubusercontent.com/3993388/107136395-07895500-6946-11eb-8706-17428a973a1b.png)

Close #193.