### PR TITLE
Upgrade dependent packages to the latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- KaTeX does not be rendered together with header/footer ([#200](https://github.com/marp-team/marp-vscode/issues/200), [#201](https://github.com/marp-team/marp-vscode/pull/201))
+
+### Changed
+
+- Upgrade to [Marp Core v1.4.3](https://github.com/marp-team/marp-core/releases/v1.4.3) and [Marp CLI v0.23.2](https://github.com/marp-team/marp-cli/releases/v0.23.2) ([#201](https://github.com/marp-team/marp-vscode/pull/201))
+- Upgrade dependent packages to the latest version ([#201](https://github.com/marp-team/marp-vscode/pull/201))
+
 ## v0.17.1 - 2021-02-07
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
-        "@marp-team/marp-cli": "^0.23.1",
-        "@marp-team/marp-core": "^1.4.2",
+        "@marp-team/marp-cli": "^0.23.2",
+        "@marp-team/marp-core": "^1.4.3",
         "axios": "^0.21.1"
       },
       "devDependencies": {
@@ -22,8 +22,8 @@
         "@types/markdown-it": "^12.0.1",
         "@types/vscode": "~1.43.0",
         "@types/yaml": "^1.9.7",
-        "@typescript-eslint/eslint-plugin": "^4.14.2",
-        "@typescript-eslint/parser": "^4.14.2",
+        "@typescript-eslint/eslint-plugin": "^4.15.0",
+        "@typescript-eslint/parser": "^4.15.0",
         "builtin-modules": "^3.2.0",
         "codecov": "^3.8.1",
         "dedent": "^0.7.0",
@@ -47,9 +47,9 @@
         "stylelint": "^13.9.0",
         "stylelint-config-prettier": "^8.0.2",
         "stylelint-config-standard": "^20.0.0",
-        "ts-jest": "^26.5.0",
+        "ts-jest": "^26.5.1",
         "tslib": "^2.1.0",
-        "typescript": "^4.1.3",
+        "typescript": "^4.1.5",
         "unified": "^9.2.0",
         "unist-util-visit": "^2.0.3",
         "utf-8-validate": "^5.0.4",
@@ -872,11 +872,11 @@
       }
     },
     "node_modules/@marp-team/marp-cli": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@marp-team/marp-cli/-/marp-cli-0.23.1.tgz",
-      "integrity": "sha512-wl2/SHO4UZxtJhMZkqV34rRSYS97qi/R9mVKbCmMOgi6qj4aV8fJXQ2RQEfYSeTUcs3at3CLMce89HYUtVTzJw==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/@marp-team/marp-cli/-/marp-cli-0.23.2.tgz",
+      "integrity": "sha512-UDWo6OvGOd9sSMwv6bG3zWqRiF3BFqJRLIylXgrJEwsIhS0IriRVwRzhvRKd25Wx0jlBM6xv02VdHQDzA2M6Fw==",
       "dependencies": {
-        "@marp-team/marp-core": "^1.4.1",
+        "@marp-team/marp-core": "^1.4.3",
         "@marp-team/marpit": "^1.6.4",
         "chokidar": "^3.5.1",
         "chrome-launcher": "^0.13.4",
@@ -885,7 +885,7 @@
         "globby": "^11.0.2",
         "import-from": "^3.0.0",
         "pptxgenjs": "^3.4.0",
-        "puppeteer-core": "~7.0.1",
+        "puppeteer-core": "7.0.1",
         "serve-index": "^1.9.1",
         "tmp": "^0.2.1",
         "v8-compile-cache": "^2.2.0",
@@ -900,9 +900,9 @@
       }
     },
     "node_modules/@marp-team/marp-core": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@marp-team/marp-core/-/marp-core-1.4.2.tgz",
-      "integrity": "sha512-OO48JS+lJ4qRXDM6a5BjpRkd9ts8muASZCB3JFp1oLar88fLQDwls6gVOadGL3ycuBAC4dszNtnLxJjibngNkg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@marp-team/marp-core/-/marp-core-1.4.3.tgz",
+      "integrity": "sha512-3JB8YvkgXuyxGvX17CNgaZxCvmOAY/hYn61b3d90hL4HZ9bL6ND3MF6QJQrUfogxztqfGfZf427rJdhRnp+uYA==",
       "dependencies": {
         "@marp-team/marpit": "^1.6.4",
         "@marp-team/marpit-svg-polyfill": "^1.7.1",
@@ -1395,13 +1395,13 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.14.2.tgz",
-      "integrity": "sha512-uMGfG7GFYK/nYutK/iqYJv6K/Xuog/vrRRZX9aEP4Zv1jsYXuvFUMDFLhUnc8WFv3D2R5QhNQL3VYKmvLS5zsQ==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.15.0.tgz",
+      "integrity": "sha512-DJgdGZW+8CFUTz5C/dnn4ONcUm2h2T0itWD85Ob5/V27Ndie8hUoX5HKyGssvR8sUMkAIlUc/AMK67Lqa3kBIQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "4.14.2",
-        "@typescript-eslint/scope-manager": "4.14.2",
+        "@typescript-eslint/experimental-utils": "4.15.0",
+        "@typescript-eslint/scope-manager": "4.15.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "lodash": "^4.17.15",
@@ -1427,15 +1427,15 @@
       }
     },
     "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.14.2.tgz",
-      "integrity": "sha512-mV9pmET4C2y2WlyHmD+Iun8SAEqkLahHGBkGqDVslHkmoj3VnxnGP4ANlwuxxfq1BsKdl/MPieDbohCEQgKrwA==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.15.0.tgz",
+      "integrity": "sha512-V4vaDWvxA2zgesg4KPgEGiomWEBpJXvY4ZX34Y3qxK8LUm5I87L+qGIOTd9tHZOARXNRt9pLbblSKiYBlGMawg==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.14.2",
-        "@typescript-eslint/types": "4.14.2",
-        "@typescript-eslint/typescript-estree": "4.14.2",
+        "@typescript-eslint/scope-manager": "4.15.0",
+        "@typescript-eslint/types": "4.15.0",
+        "@typescript-eslint/typescript-estree": "4.15.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       },
@@ -1451,14 +1451,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.14.2.tgz",
-      "integrity": "sha512-ipqSP6EuUsMu3E10EZIApOJgWSpcNXeKZaFeNKQyzqxnQl8eQCbV+TSNsl+s2GViX2d18m1rq3CWgnpOxDPgHg==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.15.0.tgz",
+      "integrity": "sha512-L6Dtbq8Bc7g2aZwnIBETpmUa9XDKCMzKVwAArnGp5Mn7PRNFjf3mUzq8UeBjL3K8t311hvevnyqXAMSmxO8Gpg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "4.14.2",
-        "@typescript-eslint/types": "4.14.2",
-        "@typescript-eslint/typescript-estree": "4.14.2",
+        "@typescript-eslint/scope-manager": "4.15.0",
+        "@typescript-eslint/types": "4.15.0",
+        "@typescript-eslint/typescript-estree": "4.15.0",
         "debug": "^4.1.1"
       },
       "engines": {
@@ -1478,13 +1478,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.14.2.tgz",
-      "integrity": "sha512-cuV9wMrzKm6yIuV48aTPfIeqErt5xceTheAgk70N1V4/2Ecj+fhl34iro/vIssJlb7XtzcaD07hWk7Jk0nKghg==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.15.0.tgz",
+      "integrity": "sha512-CSNBZnCC2jEA/a+pR9Ljh8Y+5TY5qgbPz7ICEk9WCpSEgT6Pi7H2RIjxfrrbUXvotd6ta+i27sssKEH8Azm75g==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.14.2",
-        "@typescript-eslint/visitor-keys": "4.14.2"
+        "@typescript-eslint/types": "4.15.0",
+        "@typescript-eslint/visitor-keys": "4.15.0"
       },
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -1495,9 +1495,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.14.2.tgz",
-      "integrity": "sha512-LltxawRW6wXy4Gck6ZKlBD05tCHQUj4KLn4iR69IyRiDHX3d3NCAhO+ix5OR2Q+q9bjCrHE/HKt+riZkd1At8Q==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-su4RHkJhS+iFwyqyXHcS8EGPlUVoC+XREfy5daivjLur9JP8GhvTmDipuRpcujtGC4M+GYhUOJCPDE3rC5NJrg==",
       "dev": true,
       "engines": {
         "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
@@ -1508,17 +1508,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.14.2.tgz",
-      "integrity": "sha512-ESiFl8afXxt1dNj8ENEZT12p+jl9PqRur+Y19m0Z/SPikGL6rqq4e7Me60SU9a2M28uz48/8yct97VQYaGl0Vg==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.15.0.tgz",
+      "integrity": "sha512-jG6xTmcNbi6xzZq0SdWh7wQ9cMb2pqXaUp6bUZOMsIlu5aOlxGxgE/t6L/gPybybQGvdguajXGkZKSndZJpksA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.14.2",
-        "@typescript-eslint/visitor-keys": "4.14.2",
+        "@typescript-eslint/types": "4.15.0",
+        "@typescript-eslint/visitor-keys": "4.15.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
-        "lodash": "^4.17.15",
         "semver": "^7.3.2",
         "tsutils": "^3.17.1"
       },
@@ -1536,12 +1535,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.14.2.tgz",
-      "integrity": "sha512-KBB+xLBxnBdTENs/rUgeUKO0UkPBRs2vD09oMRRIkj5BEN8PX1ToXV532desXfpQnZsYTyLLviS7JrPhdL154w==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.15.0.tgz",
+      "integrity": "sha512-RnDtJwOwFucWFAMjG3ghCG/ikImFJFEg20DI7mn4pHEx3vC48lIAoyjhffvfHmErRDboUPC7p9Z2il4CLb7qxA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "4.14.2",
+        "@typescript-eslint/types": "4.15.0",
         "eslint-visitor-keys": "^2.0.0"
       },
       "engines": {
@@ -2116,9 +2115,9 @@
       }
     },
     "node_modules/bl": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.4.tgz",
-      "integrity": "sha512-7tdr4EpSd7jJ6tuQ21vu2ke8w7pNEstzj1O8wwq6sNNzO3UDi5MA8Gny/gquCj7r2C6fHudg8tKRGyjRgmvNxQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -3486,9 +3485,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.657",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.657.tgz",
-      "integrity": "sha512-/9ROOyvEflEbaZFUeGofD+Tqs/WynbSTbNgNF+/TJJxH1ePD/e6VjZlDJpW3FFFd3nj5l3Hd8ki2vRwy+gyRFw=="
+      "version": "1.3.662",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.662.tgz",
+      "integrity": "sha512-IGBXmTGwdVGUVTnZ8ISEvkhDfhhD+CDFndG4//BhvDcEtPYiVrzoB+rzT/Y12OQCf5bvRCrVmrUbGrS9P7a6FQ=="
     },
     "node_modules/emittery": {
       "version": "0.7.2",
@@ -4951,9 +4950,9 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.5.tgz",
-      "integrity": "sha512-kBBSQbz2K0Nyn+31j/w36fUfxkBW9/gfwRWdUY1ULReH3iokVJgddZAFcD1D0xlgTmFxJCbUkUclAlc6/IDJkw=="
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
     "node_modules/growly": {
       "version": "1.3.0",
@@ -5141,9 +5140,9 @@
       }
     },
     "node_modules/highlight.js": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.5.0.tgz",
-      "integrity": "sha512-xTmvd9HiIHR6L53TMC7TKolEj65zG1XU+Onr8oi86mYa+nLcIbxTTWkpW7CsEwv/vK7u1zb8alZIMLDqqN6KTw==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.6.0.tgz",
+      "integrity": "sha512-8mlRcn5vk/r4+QcqerapwBYTe+iPL5ih6xrNylxrnBdHQiijDETfXX7VIxC3UiCRiINBJfANBAsPzAvRQj8RpQ==",
       "engines": {
         "node": "*"
       }
@@ -6923,9 +6922,9 @@
       }
     },
     "node_modules/jszip": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.5.0.tgz",
-      "integrity": "sha512-WRtu7TPCmYePR1nazfrtuF216cIVon/3GWOvHS9QR5bIwSbnxtdpma6un3jyGGNhHsKCSzn5Ypk+EkDRvTGiFA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
+      "integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
       "dependencies": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -9030,6 +9029,25 @@
         "inherits": "~2.0.3"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.2.tgz",
+      "integrity": "sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/quick-lru": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -9688,9 +9706,9 @@
       }
     },
     "node_modules/run-parallel": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
-      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "funding": [
         {
           "type": "github",
@@ -9704,7 +9722,10 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
@@ -11190,9 +11211,9 @@
       }
     },
     "node_modules/table/node_modules/ajv": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.0.4.tgz",
-      "integrity": "sha512-xzzzaqgEQfmuhbhAoqjJ8T/1okb6gAzXn/eQRNpAN1AEUoHJTNF9xCDRTtf/s3SKldtZfa+RJeTs+BQq+eZ/sw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.1.0.tgz",
+      "integrity": "sha512-svS9uILze/cXbH0z2myCK2Brqprx/+JJYK5pHicT/GQiBfzzhUVAIT6MwqJg8y4xV/zoGsUeuPuwtoiKSGE15g==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -11510,9 +11531,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.5.0.tgz",
-      "integrity": "sha512-Ya4IQgvIFNa2Mgq52KaO8yBw2W8tWp61Ecl66VjF0f5JaV8u50nGoptHVILOPGoI7SDnShmEqnYQEmyHdQ+56g==",
+      "version": "26.5.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.5.1.tgz",
+      "integrity": "sha512-G7Rmo3OJMvlqE79amJX8VJKDiRcd7/r61wh9fnvvG8cAjhA9edklGw/dCxRSQmfZ/z8NDums5srSVgwZos1qfg==",
       "dev": true,
       "dependencies": {
         "@types/jest": "26.x",
@@ -11715,9 +11736,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -13283,11 +13304,11 @@
       }
     },
     "@marp-team/marp-cli": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@marp-team/marp-cli/-/marp-cli-0.23.1.tgz",
-      "integrity": "sha512-wl2/SHO4UZxtJhMZkqV34rRSYS97qi/R9mVKbCmMOgi6qj4aV8fJXQ2RQEfYSeTUcs3at3CLMce89HYUtVTzJw==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/@marp-team/marp-cli/-/marp-cli-0.23.2.tgz",
+      "integrity": "sha512-UDWo6OvGOd9sSMwv6bG3zWqRiF3BFqJRLIylXgrJEwsIhS0IriRVwRzhvRKd25Wx0jlBM6xv02VdHQDzA2M6Fw==",
       "requires": {
-        "@marp-team/marp-core": "^1.4.1",
+        "@marp-team/marp-core": "^1.4.3",
         "@marp-team/marpit": "^1.6.4",
         "chokidar": "^3.5.1",
         "chrome-launcher": "^0.13.4",
@@ -13296,7 +13317,7 @@
         "globby": "^11.0.2",
         "import-from": "^3.0.0",
         "pptxgenjs": "^3.4.0",
-        "puppeteer-core": "~7.0.1",
+        "puppeteer-core": "7.0.1",
         "serve-index": "^1.9.1",
         "tmp": "^0.2.1",
         "v8-compile-cache": "^2.2.0",
@@ -13305,9 +13326,9 @@
       }
     },
     "@marp-team/marp-core": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@marp-team/marp-core/-/marp-core-1.4.2.tgz",
-      "integrity": "sha512-OO48JS+lJ4qRXDM6a5BjpRkd9ts8muASZCB3JFp1oLar88fLQDwls6gVOadGL3ycuBAC4dszNtnLxJjibngNkg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@marp-team/marp-core/-/marp-core-1.4.3.tgz",
+      "integrity": "sha512-3JB8YvkgXuyxGvX17CNgaZxCvmOAY/hYn61b3d90hL4HZ9bL6ND3MF6QJQrUfogxztqfGfZf427rJdhRnp+uYA==",
       "requires": {
         "@marp-team/marpit": "^1.6.4",
         "@marp-team/marpit-svg-polyfill": "^1.7.1",
@@ -13736,13 +13757,13 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.14.2.tgz",
-      "integrity": "sha512-uMGfG7GFYK/nYutK/iqYJv6K/Xuog/vrRRZX9aEP4Zv1jsYXuvFUMDFLhUnc8WFv3D2R5QhNQL3VYKmvLS5zsQ==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.15.0.tgz",
+      "integrity": "sha512-DJgdGZW+8CFUTz5C/dnn4ONcUm2h2T0itWD85Ob5/V27Ndie8hUoX5HKyGssvR8sUMkAIlUc/AMK67Lqa3kBIQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.14.2",
-        "@typescript-eslint/scope-manager": "4.14.2",
+        "@typescript-eslint/experimental-utils": "4.15.0",
+        "@typescript-eslint/scope-manager": "4.15.0",
         "debug": "^4.1.1",
         "functional-red-black-tree": "^1.0.1",
         "lodash": "^4.17.15",
@@ -13752,70 +13773,69 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.14.2.tgz",
-      "integrity": "sha512-mV9pmET4C2y2WlyHmD+Iun8SAEqkLahHGBkGqDVslHkmoj3VnxnGP4ANlwuxxfq1BsKdl/MPieDbohCEQgKrwA==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.15.0.tgz",
+      "integrity": "sha512-V4vaDWvxA2zgesg4KPgEGiomWEBpJXvY4ZX34Y3qxK8LUm5I87L+qGIOTd9tHZOARXNRt9pLbblSKiYBlGMawg==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/scope-manager": "4.14.2",
-        "@typescript-eslint/types": "4.14.2",
-        "@typescript-eslint/typescript-estree": "4.14.2",
+        "@typescript-eslint/scope-manager": "4.15.0",
+        "@typescript-eslint/types": "4.15.0",
+        "@typescript-eslint/typescript-estree": "4.15.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.14.2.tgz",
-      "integrity": "sha512-ipqSP6EuUsMu3E10EZIApOJgWSpcNXeKZaFeNKQyzqxnQl8eQCbV+TSNsl+s2GViX2d18m1rq3CWgnpOxDPgHg==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.15.0.tgz",
+      "integrity": "sha512-L6Dtbq8Bc7g2aZwnIBETpmUa9XDKCMzKVwAArnGp5Mn7PRNFjf3mUzq8UeBjL3K8t311hvevnyqXAMSmxO8Gpg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "4.14.2",
-        "@typescript-eslint/types": "4.14.2",
-        "@typescript-eslint/typescript-estree": "4.14.2",
+        "@typescript-eslint/scope-manager": "4.15.0",
+        "@typescript-eslint/types": "4.15.0",
+        "@typescript-eslint/typescript-estree": "4.15.0",
         "debug": "^4.1.1"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.14.2.tgz",
-      "integrity": "sha512-cuV9wMrzKm6yIuV48aTPfIeqErt5xceTheAgk70N1V4/2Ecj+fhl34iro/vIssJlb7XtzcaD07hWk7Jk0nKghg==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.15.0.tgz",
+      "integrity": "sha512-CSNBZnCC2jEA/a+pR9Ljh8Y+5TY5qgbPz7ICEk9WCpSEgT6Pi7H2RIjxfrrbUXvotd6ta+i27sssKEH8Azm75g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.14.2",
-        "@typescript-eslint/visitor-keys": "4.14.2"
+        "@typescript-eslint/types": "4.15.0",
+        "@typescript-eslint/visitor-keys": "4.15.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.14.2.tgz",
-      "integrity": "sha512-LltxawRW6wXy4Gck6ZKlBD05tCHQUj4KLn4iR69IyRiDHX3d3NCAhO+ix5OR2Q+q9bjCrHE/HKt+riZkd1At8Q==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-su4RHkJhS+iFwyqyXHcS8EGPlUVoC+XREfy5daivjLur9JP8GhvTmDipuRpcujtGC4M+GYhUOJCPDE3rC5NJrg==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.14.2.tgz",
-      "integrity": "sha512-ESiFl8afXxt1dNj8ENEZT12p+jl9PqRur+Y19m0Z/SPikGL6rqq4e7Me60SU9a2M28uz48/8yct97VQYaGl0Vg==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.15.0.tgz",
+      "integrity": "sha512-jG6xTmcNbi6xzZq0SdWh7wQ9cMb2pqXaUp6bUZOMsIlu5aOlxGxgE/t6L/gPybybQGvdguajXGkZKSndZJpksA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.14.2",
-        "@typescript-eslint/visitor-keys": "4.14.2",
+        "@typescript-eslint/types": "4.15.0",
+        "@typescript-eslint/visitor-keys": "4.15.0",
         "debug": "^4.1.1",
         "globby": "^11.0.1",
         "is-glob": "^4.0.1",
-        "lodash": "^4.17.15",
         "semver": "^7.3.2",
         "tsutils": "^3.17.1"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.14.2.tgz",
-      "integrity": "sha512-KBB+xLBxnBdTENs/rUgeUKO0UkPBRs2vD09oMRRIkj5BEN8PX1ToXV532desXfpQnZsYTyLLviS7JrPhdL154w==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.15.0.tgz",
+      "integrity": "sha512-RnDtJwOwFucWFAMjG3ghCG/ikImFJFEg20DI7mn4pHEx3vC48lIAoyjhffvfHmErRDboUPC7p9Z2il4CLb7qxA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "4.14.2",
+        "@typescript-eslint/types": "4.15.0",
         "eslint-visitor-keys": "^2.0.0"
       }
     },
@@ -14235,9 +14255,9 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
     "bl": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.4.tgz",
-      "integrity": "sha512-7tdr4EpSd7jJ6tuQ21vu2ke8w7pNEstzj1O8wwq6sNNzO3UDi5MA8Gny/gquCj7r2C6fHudg8tKRGyjRgmvNxQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "requires": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -15296,9 +15316,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "electron-to-chromium": {
-      "version": "1.3.657",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.657.tgz",
-      "integrity": "sha512-/9ROOyvEflEbaZFUeGofD+Tqs/WynbSTbNgNF+/TJJxH1ePD/e6VjZlDJpW3FFFd3nj5l3Hd8ki2vRwy+gyRFw=="
+      "version": "1.3.662",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.662.tgz",
+      "integrity": "sha512-IGBXmTGwdVGUVTnZ8ISEvkhDfhhD+CDFndG4//BhvDcEtPYiVrzoB+rzT/Y12OQCf5bvRCrVmrUbGrS9P7a6FQ=="
     },
     "emittery": {
       "version": "0.7.2",
@@ -16444,9 +16464,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.5.tgz",
-      "integrity": "sha512-kBBSQbz2K0Nyn+31j/w36fUfxkBW9/gfwRWdUY1ULReH3iokVJgddZAFcD1D0xlgTmFxJCbUkUclAlc6/IDJkw=="
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
     "growly": {
       "version": "1.3.0",
@@ -16589,9 +16609,9 @@
       }
     },
     "highlight.js": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.5.0.tgz",
-      "integrity": "sha512-xTmvd9HiIHR6L53TMC7TKolEj65zG1XU+Onr8oi86mYa+nLcIbxTTWkpW7CsEwv/vK7u1zb8alZIMLDqqN6KTw=="
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.6.0.tgz",
+      "integrity": "sha512-8mlRcn5vk/r4+QcqerapwBYTe+iPL5ih6xrNylxrnBdHQiijDETfXX7VIxC3UiCRiINBJfANBAsPzAvRQj8RpQ=="
     },
     "hosted-git-info": {
       "version": "2.8.8",
@@ -17945,9 +17965,9 @@
       }
     },
     "jszip": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.5.0.tgz",
-      "integrity": "sha512-WRtu7TPCmYePR1nazfrtuF216cIVon/3GWOvHS9QR5bIwSbnxtdpma6un3jyGGNhHsKCSzn5Ypk+EkDRvTGiFA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.6.0.tgz",
+      "integrity": "sha512-jgnQoG9LKnWO3mnVNBnfhkh0QknICd1FGSrXcgrl67zioyJ4wgx25o9ZqwNtrROSflGBCGYnJfjrIyRIby1OoQ==",
       "requires": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -19589,6 +19609,11 @@
         "inherits": "~2.0.3"
       }
     },
+    "queue-microtask": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.2.tgz",
+      "integrity": "sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg=="
+    },
     "quick-lru": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -20090,9 +20115,12 @@
       "dev": true
     },
     "run-parallel": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
-      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -21317,9 +21345,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "7.0.4",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.0.4.tgz",
-          "integrity": "sha512-xzzzaqgEQfmuhbhAoqjJ8T/1okb6gAzXn/eQRNpAN1AEUoHJTNF9xCDRTtf/s3SKldtZfa+RJeTs+BQq+eZ/sw==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.1.0.tgz",
+          "integrity": "sha512-svS9uILze/cXbH0z2myCK2Brqprx/+JJYK5pHicT/GQiBfzzhUVAIT6MwqJg8y4xV/zoGsUeuPuwtoiKSGE15g==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -21575,9 +21603,9 @@
       "dev": true
     },
     "ts-jest": {
-      "version": "26.5.0",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.5.0.tgz",
-      "integrity": "sha512-Ya4IQgvIFNa2Mgq52KaO8yBw2W8tWp61Ecl66VjF0f5JaV8u50nGoptHVILOPGoI7SDnShmEqnYQEmyHdQ+56g==",
+      "version": "26.5.1",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.5.1.tgz",
+      "integrity": "sha512-G7Rmo3OJMvlqE79amJX8VJKDiRcd7/r61wh9fnvvG8cAjhA9edklGw/dCxRSQmfZ/z8NDums5srSVgwZos1qfg==",
       "dev": true,
       "requires": {
         "@types/jest": "26.x",
@@ -21740,9 +21768,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
+      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
       "dev": true
     },
     "uc.micro": {

--- a/package.json
+++ b/package.json
@@ -228,8 +228,8 @@
     "@types/markdown-it": "^12.0.1",
     "@types/vscode": "~1.43.0",
     "@types/yaml": "^1.9.7",
-    "@typescript-eslint/eslint-plugin": "^4.14.2",
-    "@typescript-eslint/parser": "^4.14.2",
+    "@typescript-eslint/eslint-plugin": "^4.15.0",
+    "@typescript-eslint/parser": "^4.15.0",
     "builtin-modules": "^3.2.0",
     "codecov": "^3.8.1",
     "dedent": "^0.7.0",
@@ -253,9 +253,9 @@
     "stylelint": "^13.9.0",
     "stylelint-config-prettier": "^8.0.2",
     "stylelint-config-standard": "^20.0.0",
-    "ts-jest": "^26.5.0",
+    "ts-jest": "^26.5.1",
     "tslib": "^2.1.0",
-    "typescript": "^4.1.3",
+    "typescript": "^4.1.5",
     "unified": "^9.2.0",
     "unist-util-visit": "^2.0.3",
     "utf-8-validate": "^5.0.4",
@@ -263,8 +263,8 @@
     "yaml": "^1.10.0"
   },
   "dependencies": {
-    "@marp-team/marp-cli": "^0.23.1",
-    "@marp-team/marp-core": "^1.4.2",
+    "@marp-team/marp-cli": "^0.23.2",
+    "@marp-team/marp-core": "^1.4.3",
     "axios": "^0.21.1"
   }
 }


### PR DESCRIPTION
Upgraded development dependent packages to the latest version, through `npx upm-check -u` and `npm update`.

### Notable changes

- Upgraded to [Marp Core v1.4.3](https://github.com/marp-team/marp-core/releases/tag/v1.4.3) and [Marp CLI v0.23.2](https://github.com/marp-team/marp-cli/releases/tag/v0.23.2).
  - Fixed: KaTeX does not be rendered together with header/footer (marp-team/marp-core#214, marp-team/marp-core#215)

Closes #200.