### PR TITLE
Support virtual workspaces

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,13 +83,6 @@ jobs:
     steps:
       - audit
 
-  unit-electron7:
-    executor:
-      name: node
-      version: '12.8.1'
-    steps:
-      - test
-
   unit-electron9:
     executor:
       name: node
@@ -104,16 +97,23 @@ jobs:
     steps:
       - test
 
+  unit-electron12:
+    executor:
+      name: node
+      version: '14.16.0'
+    steps:
+      - test
+
 workflows:
   test:
     jobs:
       - audit
-      - unit-electron7:
-          requires:
-            - audit
       - unit-electron9:
           requires:
             - audit
       - unit-electron11:
+          requires:
+            - audit
+      - unit-electron12:
           requires:
             - audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Breaking
+
+- VS Code >= 1.52 is now required ([#225](https://github.com/marp-team/marp-vscode/pull/225))
+
 ### Added
 
 - Apply [`markdown.preview.typographer` for VS Code 1.56](https://code.visualstudio.com/updates/v1_56#_markdown-preview-typographer-support) to Marp preview and the export result ([#226](https://github.com/marp-team/marp-vscode/issues/226), [#228](https://github.com/marp-team/marp-vscode/pull/228))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Apply [`markdown.preview.typographer` for VS Code 1.56](https://code.visualstudio.com/updates/v1_56#_markdown-preview-typographer-support) to Marp preview and the export result ([#226](https://github.com/marp-team/marp-vscode/issues/226), [#228](https://github.com/marp-team/marp-vscode/pull/228))
+- Improved support for a [virtual workspace](https://code.visualstudio.com/updates/v1_56#_define-whether-your-extension-supports-a-virtual-workspace) ([#224](https://github.com/marp-team/marp-vscode/issues/224), [#225](https://github.com/marp-team/marp-vscode/pull/225))
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
-        "@marp-team/marp-cli": "file:../marp-cli/marp-team-marp-cli-1.0.1.tgz",
+        "@marp-team/marp-cli": "^1.0.2",
         "@marp-team/marp-core": "^2.0.1",
         "axios": "^0.21.1"
       },
@@ -1852,10 +1852,9 @@
       }
     },
     "node_modules/@marp-team/marp-cli": {
-      "version": "1.0.1",
-      "resolved": "file:../marp-cli/marp-team-marp-cli-1.0.1.tgz",
-      "integrity": "sha512-LBwqNKIyvZa8X66e4G1lFSOfADBtD8b78jW59nfPQCZlVcen/it38zfvAzuuUuBpRM44kRFcMgWUmwezNqJoSw==",
-      "license": "MIT",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marp-team/marp-cli/-/marp-cli-1.0.2.tgz",
+      "integrity": "sha512-8lHzMhhIqU3gEpX8tbiHbhQxuZZYRJY+UWgUAlqNbm5fHx5VTUJhK+tLZlG1pyffwoRQmUffIBsiaXUF2iUiJA==",
       "dependencies": {
         "@marp-team/marp-core": "^2.0.1",
         "@marp-team/marpit": "^2.0.1",
@@ -15400,8 +15399,9 @@
       }
     },
     "@marp-team/marp-cli": {
-      "version": "file:../marp-cli/marp-team-marp-cli-1.0.1.tgz",
-      "integrity": "sha512-LBwqNKIyvZa8X66e4G1lFSOfADBtD8b78jW59nfPQCZlVcen/it38zfvAzuuUuBpRM44kRFcMgWUmwezNqJoSw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marp-team/marp-cli/-/marp-cli-1.0.2.tgz",
+      "integrity": "sha512-8lHzMhhIqU3gEpX8tbiHbhQxuZZYRJY+UWgUAlqNbm5fHx5VTUJhK+tLZlG1pyffwoRQmUffIBsiaXUF2iUiJA==",
       "requires": {
         "@marp-team/marp-core": "^2.0.1",
         "@marp-team/marpit": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
-        "@marp-team/marp-cli": "^1.0.1",
+        "@marp-team/marp-cli": "file:../marp-cli/marp-team-marp-cli-1.0.1.tgz",
         "@marp-team/marp-core": "^2.0.1",
         "axios": "^0.21.1"
       },
@@ -18,6 +18,7 @@
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^11.2.1",
         "@rollup/plugin-typescript": "^8.2.1",
+        "@types/express": "^4.17.11",
         "@types/jest": "^26.0.23",
         "@types/lodash.debounce": "^4.0.6",
         "@types/markdown-it": "^12.0.1",
@@ -33,12 +34,14 @@
         "eslint-import-resolver-typescript": "^2.4.0",
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-jest": "^24.3.6",
+        "express": "^4.17.1",
         "jest": "^26.6.3",
         "jest-junit": "^12.0.0",
         "lodash.debounce": "^4.0.8",
         "markdown-it": "^12.0.6",
         "nanoid": "^3.1.22",
         "npm-run-all": "^4.1.5",
+        "portfinder": "^1.0.28",
         "prettier": "^2.2.1",
         "rehype-parse": "^7.0.1",
         "remark-parse": "^9.0.0",
@@ -1850,8 +1853,9 @@
     },
     "node_modules/@marp-team/marp-cli": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@marp-team/marp-cli/-/marp-cli-1.0.1.tgz",
-      "integrity": "sha512-nrMwsdMM8Tvc5cwjKef1BYcoIN++XtRWlMn9/K2LY7qHDSI58UgY419ol3zm+4/tn8U9cVpcHO6siRmS0MqXxg==",
+      "resolved": "file:../marp-cli/marp-team-marp-cli-1.0.1.tgz",
+      "integrity": "sha512-LBwqNKIyvZa8X66e4G1lFSOfADBtD8b78jW59nfPQCZlVcen/it38zfvAzuuUuBpRM44kRFcMgWUmwezNqJoSw==",
+      "license": "MIT",
       "dependencies": {
         "@marp-team/marp-core": "^2.0.1",
         "@marp-team/marpit": "^2.0.1",
@@ -2258,11 +2262,53 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.34",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.34.tgz",
+      "integrity": "sha512-ePPA/JuI+X0vb+gSWlPKOY0NdNAie/rPUqX2GUPpbZwiKTkSPhjXWuee47E4MtE54QVzGCQMQkAL6JhV2E1+cQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.11.tgz",
+      "integrity": "sha512-no+R6rW60JEc59977wIxreQVsIEOAYwgCqldrA/vkpCnbD7MqTefO97lmoBe4WE0F156bC4uLSP1XHDOySnChg==",
+      "dev": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.19.tgz",
+      "integrity": "sha512-DJOSHzX7pCiSElWaGR8kCprwibCB/3yW6vcT8VG3P0SJjnv19gnWG/AZMfM60Xj/YJIp/YCaDHyvzsFVeniARA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.4",
@@ -2415,6 +2461,18 @@
       "integrity": "sha512-O3SQC6+6AySHwrspYn2UvC6tjo6jCTMMmylxZUFhE1CulVu5l3AxU6ca9lrJDTQDVllF62LIxVSx5fuYL6LiZg==",
       "dev": true
     },
+    "node_modules/@types/qs": {
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.6.tgz",
+      "integrity": "sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA==",
+      "dev": true
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
+      "dev": true
+    },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -2423,6 +2481,22 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.13.9",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.9.tgz",
+      "integrity": "sha512-ZFqF6qa48XsPdjXV5Gsz0Zqmux2PerNd3a/ktL45mHpa19cuMi/cL8tcxdAx497yRh+QtYPuofjT9oWw9P7nkA==",
+      "dev": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/mime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+      "dev": true
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.0",
@@ -2925,6 +2999,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.14"
       }
     },
     "node_modules/asynckit": {
@@ -6297,9 +6380,9 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "node_modules/html-encoding-sniffer": {
@@ -8596,9 +8679,9 @@
       }
     },
     "node_modules/meow/node_modules/read-pkg/node_modules/hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "node_modules/meow/node_modules/read-pkg/node_modules/normalize-package-data": {
@@ -8700,17 +8783,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/mime-db": {
@@ -9770,6 +9842,29 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/portfinder": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
+      "integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
+      "dev": true,
+      "dependencies": {
+        "async": "^2.6.2",
+        "debug": "^3.1.1",
+        "mkdirp": "^0.5.5"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/portfinder/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/posix-character-classes": {
@@ -11271,6 +11366,17 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "node_modules/send/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/send/node_modules/ms": {
       "version": "2.1.1",
@@ -13475,6 +13581,18 @@
         "markdown-it": "bin/markdown-it.js"
       }
     },
+    "node_modules/vsce/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/vsce/node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -15282,9 +15400,8 @@
       }
     },
     "@marp-team/marp-cli": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@marp-team/marp-cli/-/marp-cli-1.0.1.tgz",
-      "integrity": "sha512-nrMwsdMM8Tvc5cwjKef1BYcoIN++XtRWlMn9/K2LY7qHDSI58UgY419ol3zm+4/tn8U9cVpcHO6siRmS0MqXxg==",
+      "version": "file:../marp-cli/marp-team-marp-cli-1.0.1.tgz",
+      "integrity": "sha512-LBwqNKIyvZa8X66e4G1lFSOfADBtD8b78jW59nfPQCZlVcen/it38zfvAzuuUuBpRM44kRFcMgWUmwezNqJoSw==",
       "requires": {
         "@marp-team/marp-core": "^2.0.1",
         "@marp-team/marpit": "^2.0.1",
@@ -15586,11 +15703,53 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/body-parser": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
+      "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.34",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.34.tgz",
+      "integrity": "sha512-ePPA/JuI+X0vb+gSWlPKOY0NdNAie/rPUqX2GUPpbZwiKTkSPhjXWuee47E4MtE54QVzGCQMQkAL6JhV2E1+cQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/estree": {
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
+    },
+    "@types/express": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.11.tgz",
+      "integrity": "sha512-no+R6rW60JEc59977wIxreQVsIEOAYwgCqldrA/vkpCnbD7MqTefO97lmoBe4WE0F156bC4uLSP1XHDOySnChg==",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.19.tgz",
+      "integrity": "sha512-DJOSHzX7pCiSElWaGR8kCprwibCB/3yW6vcT8VG3P0SJjnv19gnWG/AZMfM60Xj/YJIp/YCaDHyvzsFVeniARA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
     },
     "@types/graceful-fs": {
       "version": "4.1.4",
@@ -15743,6 +15902,18 @@
       "integrity": "sha512-O3SQC6+6AySHwrspYn2UvC6tjo6jCTMMmylxZUFhE1CulVu5l3AxU6ca9lrJDTQDVllF62LIxVSx5fuYL6LiZg==",
       "dev": true
     },
+    "@types/qs": {
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.6.tgz",
+      "integrity": "sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA==",
+      "dev": true
+    },
+    "@types/range-parser": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
+      "dev": true
+    },
     "@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -15750,6 +15921,24 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/serve-static": {
+      "version": "1.13.9",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.9.tgz",
+      "integrity": "sha512-ZFqF6qa48XsPdjXV5Gsz0Zqmux2PerNd3a/ktL45mHpa19cuMi/cL8tcxdAx497yRh+QtYPuofjT9oWw9P7nkA==",
+      "dev": true,
+      "requires": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      },
+      "dependencies": {
+        "@types/mime": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+          "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+          "dev": true
+        }
       }
     },
     "@types/stack-utils": {
@@ -16092,6 +16281,15 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
       "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
       "dev": true
+    },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -18718,9 +18916,9 @@
       "integrity": "sha512-oFLl873u4usRM9K63j4ME9u3etNF0PLiJhSQ8rdfuL51Wn3zkD6drf9ZW0dOzjnZI22YYG24z30JcmfCZjMgYg=="
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "html-encoding-sniffer": {
@@ -20479,9 +20677,9 @@
           },
           "dependencies": {
             "hosted-git-info": {
-              "version": "2.8.8",
-              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-              "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+              "version": "2.8.9",
+              "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+              "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
               "dev": true
             },
             "normalize-package-data": {
@@ -20576,11 +20774,6 @@
         "braces": "^3.0.1",
         "picomatch": "^2.2.3"
       }
-    },
-    "mime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
       "version": "1.45.0",
@@ -21391,6 +21584,28 @@
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
           "dev": true
+        }
+      }
+    },
+    "portfinder": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
+      "integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.2",
+        "debug": "^3.1.1",
+        "mkdirp": "^0.5.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
         }
       }
     },
@@ -22561,6 +22776,11 @@
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             }
           }
+        },
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
         },
         "ms": {
           "version": "2.1.1",
@@ -24353,6 +24573,12 @@
             "mdurl": "^1.0.1",
             "uc.micro": "^1.0.5"
           }
+        },
+        "mime": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+          "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+          "dev": true
         },
         "semver": {
           "version": "5.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/jest": "^26.0.23",
         "@types/lodash.debounce": "^4.0.6",
         "@types/markdown-it": "^12.0.1",
-        "@types/vscode": "~1.43.0",
+        "@types/vscode": "~1.52.0",
         "@typescript-eslint/eslint-plugin": "^4.22.0",
         "@typescript-eslint/parser": "^4.22.0",
         "bufferutil": "^4.0.3",
@@ -61,7 +61,7 @@
         "yaml": "^1.10.2"
       },
       "engines": {
-        "vscode": "^1.43.0"
+        "vscode": "^1.52.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2512,9 +2512,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.43.0.tgz",
-      "integrity": "sha512-kIaR9qzd80rJOxePKpCB/mdy00mz8Apt2QA5Y6rdrKFn13QNFNeP3Hzmsf37Bwh/3cS7QjtAeGSK7wSqAU0sYQ==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
+      "integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -15956,9 +15956,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.43.0.tgz",
-      "integrity": "sha512-kIaR9qzd80rJOxePKpCB/mdy00mz8Apt2QA5Y6rdrKFn13QNFNeP3Hzmsf37Bwh/3cS7QjtAeGSK7wSqAU0sYQ==",
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
+      "integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
       "dev": true
     },
     "@types/yargs": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
     "onCommand:markdown.marp.showQuickPick",
     "onCommand:markdown.marp.toggleMarpPreview"
   ],
+  "capabilities": {
+    "virtualWorkspaces": true
+  },
   "contributes": {
     "commands": [
       {
@@ -210,6 +213,7 @@
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^11.2.1",
     "@rollup/plugin-typescript": "^8.2.1",
+    "@types/express": "^4.17.11",
     "@types/jest": "^26.0.23",
     "@types/lodash.debounce": "^4.0.6",
     "@types/markdown-it": "^12.0.1",
@@ -225,12 +229,14 @@
     "eslint-import-resolver-typescript": "^2.4.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jest": "^24.3.6",
+    "express": "^4.17.1",
     "jest": "^26.6.3",
     "jest-junit": "^12.0.0",
     "lodash.debounce": "^4.0.8",
     "markdown-it": "^12.0.6",
     "nanoid": "^3.1.22",
     "npm-run-all": "^4.1.5",
+    "portfinder": "^1.0.28",
     "prettier": "^2.2.1",
     "rehype-parse": "^7.0.1",
     "remark-parse": "^9.0.0",
@@ -250,7 +256,7 @@
     "yaml": "^1.10.2"
   },
   "dependencies": {
-    "@marp-team/marp-cli": "^1.0.1",
+    "@marp-team/marp-cli": "file:../marp-cli/marp-team-marp-cli-1.0.1.tgz",
     "@marp-team/marp-core": "^2.0.1",
     "axios": "^0.21.1"
   }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/marp-team/marp-vscode"
   },
   "engines": {
-    "vscode": "^1.43.0"
+    "vscode": "^1.52.0"
   },
   "main": "./lib/extension.js",
   "icon": "images/icon.png",
@@ -217,7 +217,7 @@
     "@types/jest": "^26.0.23",
     "@types/lodash.debounce": "^4.0.6",
     "@types/markdown-it": "^12.0.1",
-    "@types/vscode": "~1.43.0",
+    "@types/vscode": "~1.52.0",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
     "bufferutil": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -256,7 +256,7 @@
     "yaml": "^1.10.2"
   },
   "dependencies": {
-    "@marp-team/marp-cli": "file:../marp-cli/marp-team-marp-cli-1.0.1.tgz",
+    "@marp-team/marp-cli": "^1.0.2",
     "@marp-team/marp-core": "^2.0.1",
     "axios": "^0.21.1"
   }

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -16,7 +16,7 @@ const uriInstances: Record<string, any> = {}
 const uriInstance = (path: string) =>
   uriInstances[path] ||
   (() => {
-    const uri = { fsPath: path, with: jest.fn(() => uri) }
+    const uri = { path, scheme: 'file', fsPath: path, with: jest.fn(() => uri) }
     return uri
   })()
 

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -1,3 +1,5 @@
+import { TextEncoder } from 'util'
+
 type MockedConf = Record<string, any>
 
 const defaultVSCodeVersion = 'v1.36.0'
@@ -92,7 +94,7 @@ export const FileSystem = {
     size: 0,
     type: FileType.File,
   })),
-  readFile: jest.fn().mockResolvedValue('readFile'),
+  readFile: jest.fn().mockResolvedValue(new TextEncoder().encode('readFile')),
 }
 
 export enum FileType {

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -85,6 +85,23 @@ export const env = {
   openExternal: jest.fn(),
 }
 
+export const FileSystem = {
+  stat: jest.fn(async () => ({
+    ctime: 0,
+    mtime: new Date().getTime(),
+    size: 0,
+    type: FileType.File,
+  })),
+  readFile: jest.fn().mockResolvedValue('readFile'),
+}
+
+export enum FileType {
+  Unknown = 0,
+  File = 1,
+  Directory = 2,
+  SymbolicLink = 64,
+}
+
 export const languages = {
   createDiagnosticCollection: jest.fn((name) => ({
     name,
@@ -115,6 +132,7 @@ export const workspace = {
     onDidChange: jest.fn(),
     onDidDelete: jest.fn(),
   })),
+  fs: FileSystem,
   getConfiguration: jest.fn((section?: string) => ({
     get: jest.fn(
       (subSection?: string) =>

--- a/src/commands/export.test.ts
+++ b/src/commands/export.test.ts
@@ -97,8 +97,10 @@ describe('#saveDialog', () => {
 })
 
 describe('#doExport', () => {
-  const saveURI: any = { fsPath: '/tmp/to.pdf' }
-  const document: any = { uri: { scheme: 'file', fsPath: '/tmp/md.md' } }
+  const saveURI: any = { path: '/tmp/to.pdf', fsPath: '/tmp/to.pdf' }
+  const document: any = {
+    uri: { scheme: 'file', path: '/tmp/md.md', fsPath: '/tmp/md.md' },
+  }
 
   it('exports passed document via Marp CLI and opens it', async () => {
     const runMarpCLI = jest.spyOn(marpCli, 'default').mockImplementation()

--- a/src/marp-cli.test.ts
+++ b/src/marp-cli.test.ts
@@ -23,14 +23,16 @@ describe('Marp CLI integration', () => {
 
   it('runs Marp CLI with passed args', async () => {
     const marpCliSpy = jest.spyOn(marpCliModule, 'marpCli')
-    await runMarpCli('--version')
+    await runMarpCli(['--version'])
 
-    expect(marpCliSpy).toHaveBeenCalledWith(['--version'])
+    expect(marpCliSpy).toHaveBeenCalledWith(['--version'], undefined)
   })
 
   it('throws MarpCLIError when returned error exit code', async () => {
     jest.spyOn(marpCliModule, 'marpCli').mockResolvedValue(1)
-    await expect(runMarpCli('--version')).rejects.toThrow(marpCli.MarpCLIError)
+    await expect(runMarpCli(['--version'])).rejects.toThrow(
+      marpCli.MarpCLIError
+    )
   })
 
   it.each`
@@ -58,7 +60,7 @@ describe('Marp CLI integration', () => {
           )
 
         for (const fragment of expected) {
-          await expect(runMarpCli('--version')).rejects.toThrow(fragment)
+          await expect(runMarpCli(['--version'])).rejects.toThrow(fragment)
         }
       } finally {
         Object.defineProperty(process, 'platform', { value: originalPlatform })
@@ -80,7 +82,7 @@ describe('Marp CLI integration', () => {
           return 0
         })
 
-      await runMarpCli('--version')
+      await runMarpCli(['--version'])
       expect(marpCliSpy).toHaveBeenCalled()
       expect(process.env.CHROME_PATH).toBe(CHROME_PATH)
     })

--- a/src/marp-cli.test.ts
+++ b/src/marp-cli.test.ts
@@ -149,10 +149,6 @@ describe('#createWorkFile', () => {
   })
 
   it('creates tmpfile to os specific directory when failed all creations', async () => {
-    ;(fs as any).writeFile.mockImplementationOnce((_, __, cb) =>
-      cb(new Error())
-    )
-
     const workFile = await createWorkFile({
       getText: jest.fn(),
       isDirty: true,

--- a/src/option.ts
+++ b/src/option.ts
@@ -66,30 +66,37 @@ export const marpCoreOptionForCLI = async (
 
   const workspaceFolder = workspace.getWorkspaceFolder(uri)
   const parentFolder = uri.scheme === 'file' && path.dirname(uri.fsPath)
-  const baseFolder = workspaceFolder ? workspaceFolder.uri.fsPath : parentFolder
+
+  const baseFolder = (() => {
+    if (workspaceFolder) return workspaceFolder.uri
+    if (parentFolder) return Uri.parse(`file:${parentFolder}`, true)
+
+    return undefined
+  })()
 
   const themeFiles: WorkFile[] = (
     await Promise.all(
-      themes
-        .loadStyles(baseFolder ? Uri.parse(`file:${baseFolder}`) : undefined)
-        .map((promise) =>
-          promise.then(
-            async (theme) => {
-              if (theme.type === ThemeType.File) {
-                return { path: theme.path, cleanup: () => Promise.resolve() }
-              }
+      themes.loadStyles(baseFolder).map((promise) =>
+        promise.then(
+          async (theme) => {
+            if (theme.type === ThemeType.File) {
+              return { path: theme.path, cleanup: () => Promise.resolve() }
+            }
 
-              if (theme.type === ThemeType.Remote) {
-                const cssName = `.marp-vscode-cli-theme-${nanoid()}.css`
-                const tmp = path.join(tmpdir(), cssName)
+            if (
+              theme.type === ThemeType.Remote ||
+              theme.type === ThemeType.VirtualFS
+            ) {
+              const cssName = `.marp-vscode-cli-theme-${nanoid()}.css`
+              const tmp = path.join(tmpdir(), cssName)
 
-                await promisify(writeFile)(tmp, theme.css)
-                return { path: tmp, cleanup: () => promisify(unlink)(tmp) }
-              }
-            },
-            (e) => console.error(e)
-          )
+              await promisify(writeFile)(tmp, theme.css)
+              return { path: tmp, cleanup: () => promisify(unlink)(tmp) }
+            }
+          },
+          (e) => console.error(e)
         )
+      )
     )
   ).filter((w): w is WorkFile => !!w)
 

--- a/src/option.ts
+++ b/src/option.ts
@@ -43,9 +43,12 @@ export const marpCoreOptionForPreview = (
   return cachedPreviewOption
 }
 
-export const marpCoreOptionForCLI = async ({ uri }: TextDocument) => {
+export const marpCoreOptionForCLI = async (
+  { uri }: TextDocument,
+  { allowLocalFiles = true }: { allowLocalFiles?: boolean } = {}
+) => {
   const baseOpts = {
-    allowLocalFiles: true,
+    allowLocalFiles,
     html: marpConfiguration().get<boolean>('enableHtml') || undefined,
     options: {
       markdown: {

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -141,7 +141,7 @@ export class Themes {
             const { pathname } = new URL('.', themePath)
 
             return new RelativePattern(
-              baseUri.with({ path: pathname }).toString(),
+              baseUri.with({ path: pathname }),
               baseUri.path.split('/').pop()! // eslint-disable-line @typescript-eslint/no-non-null-assertion
             )
           } catch (e) {

--- a/src/workspace-proxy-server.test.ts
+++ b/src/workspace-proxy-server.test.ts
@@ -1,0 +1,71 @@
+import axios from 'axios'
+import { FileType, Uri, workspace } from 'vscode'
+import {
+  createWorkspaceProxyServer,
+  WorkspaceProxyServer,
+} from './workspace-proxy-server'
+
+jest.mock('vscode')
+
+describe('Workspace Proxy Server', () => {
+  let server: WorkspaceProxyServer | undefined
+
+  const wsUri: Uri = Object.assign(Uri.parse('untitled:untitled'), {
+    with: jest.fn(() => wsUri),
+  })
+  const wsFolder: any = { uri: wsUri }
+
+  beforeEach(() => {
+    ;(wsUri.with as any).mockReset()
+    server = undefined
+  })
+
+  afterEach(() => server?.dispose())
+
+  it('listens proxy server', async () => {
+    server = await createWorkspaceProxyServer(wsFolder)
+    expect(server.port).toBeGreaterThanOrEqual(8192)
+
+    const response = await axios.get(
+      `http://127.0.0.1:${server.port}/test.png?query`
+    )
+    expect(response.status).toBe(200)
+    expect(response.data).toMatchInlineSnapshot(`"readFile"`)
+
+    expect(response.headers).toHaveProperty(
+      'content-type',
+      expect.stringContaining('image/png')
+    )
+    expect(wsUri.with).toHaveBeenCalledWith({
+      path: '/test.png',
+      query: '?query',
+      fragment: '',
+    })
+    expect(workspace.fs.readFile).toHaveBeenCalled()
+  })
+
+  it('returns 404 when FileSystem.stat throws error', async () => {
+    jest.spyOn(workspace.fs, 'stat').mockRejectedValue(new Error('err'))
+    server = await createWorkspaceProxyServer(wsFolder)
+
+    const response = await axios.get(`http://127.0.0.1:${server.port}/test`, {
+      validateStatus: () => true,
+    })
+    expect(response.status).toBe(404)
+  })
+
+  it('returns 404 when FileSystem.stat returns with directory type', async () => {
+    jest.spyOn(workspace.fs, 'stat').mockResolvedValue({
+      ctime: 0,
+      mtime: new Date().getDate(),
+      size: 0,
+      type: FileType.Directory,
+    })
+    server = await createWorkspaceProxyServer(wsFolder)
+
+    const response = await axios.get(`http://127.0.0.1:${server.port}/test`, {
+      validateStatus: () => true,
+    })
+    expect(response.status).toBe(404)
+  })
+})

--- a/src/workspace-proxy-server.ts
+++ b/src/workspace-proxy-server.ts
@@ -1,0 +1,57 @@
+import type { Server } from 'http'
+import path from 'path'
+import { URL } from 'url'
+import express from 'express'
+import { getPortPromise } from 'portfinder'
+import { FileType, workspace, WorkspaceFolder } from 'vscode'
+
+export interface WorkspaceProxyServer {
+  dispose: () => void
+  port: number
+}
+
+export const createWorkspaceProxyServer = async (
+  workspaceFolder: WorkspaceFolder
+): Promise<WorkspaceProxyServer> => {
+  const port = await getPortPromise({
+    port: 8192 + Math.floor(Math.random() * 10000),
+  })
+
+  const app = express().get('*', async (req, res) => {
+    const url = new URL(req.url, `http://${req.headers.host}`)
+    const vscodeUri = workspaceFolder.uri.with({
+      fragment: url.hash,
+      path: url.pathname,
+      query: url.search,
+    })
+
+    try {
+      const urlExt = path.extname(url.pathname)
+      if (urlExt) res.type(urlExt)
+
+      const fileStat = await workspace.fs.stat(vscodeUri)
+
+      res
+        .header('Content-Length', fileStat.size.toString())
+        .header('Last-Modified', new Date(fileStat.mtime).toUTCString())
+
+      if (!(fileStat.type & FileType.Directory)) {
+        res
+          .status(200)
+          .send(Buffer.from(await workspace.fs.readFile(vscodeUri)))
+
+        return
+      }
+    } catch (e) {
+      // fallback
+    }
+
+    res.status(404).send('Not found')
+  })
+
+  const server = await new Promise<Server>((res) => {
+    const _server = app.listen(port, '127.0.0.1', () => res(_server))
+  })
+
+  return { port, dispose: () => server.close() }
+}


### PR DESCRIPTION
We're following [VS Code's call-to-action](https://code.visualstudio.com/updates/v1_56#_define-whether-your-extension-supports-a-virtual-workspace). This PR will improve PDF/PPTX/image export and resolving theme CSS in the virtual workspace. Close #224.

It depends on marp-team/marp-cli#343.

## Approaches

### Export action

Export command is depending on Marp CLI and Chromium so the work file should always place on the local file system. Thus, I've judged the most of exist codes using `fs` are not required to replace.

Currently PDF/PPTX/image export (using Chromium) cannot resolve virtual assets provided by VS Code and extensions. So we're providing a simple local proxy during export process. By forcing base URL of work file to an address of the proxy, Chromium for conversion can consume presentation assets correctly.

### Resolving custom theme CSS

Paths for custom theme CSS must be a relative path from the workspace. Now we are handling the case of in a virtual workspace while theme resolution. Auto-reloading CSS theme is also working even if in virtual workspace.

> :warning: [`FileSystemWatcher`](https://code.visualstudio.com/api/references/vscode-api#FileSystemWatcher) looks like supporting the custom scheme for a virtual workspace, but it requires VS Code >= 1.52.

## ToDo

- [x] Release new Marp CLI version including marp-team/marp-cli#343
- [x] Update tests