### PR TITLE
Get ready for workspace trust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Breaking
+
+- VS Code >= 1.56 is now required ([#231](https://github.com/marp-team/marp-vscode/pull/231))
+
+### Changed
+
+- Support [Workspace Trust](https://code.visualstudio.com/updates/v1_56#_workspace-trust): Restrict some features in the untrusted workspace ([#231](https://github.com/marp-team/marp-vscode/pull/231))
+
 ## v0.19.1 - 2021-05-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -135,9 +135,17 @@ You can fold the content of slide in editor while editing Marp Markdown.
   <img src="https://raw.githubusercontent.com/marp-team/marp-vscode/main/docs/fold.gif" alt="Slide folding in editor" width="360" />
 </p>
 
-### Enable HTML in Marp Markdown
+### Security
 
-You can enable previsualization of HTML code within Marp Markdown with the `markdown.marp.enableHtml` option. This feature is disabled as a default because it could allow script injection from untrusted Markdown files. Use with caution.
+#### [Workspace Trust](https://github.com/microsoft/vscode/issues/106488) <!-- TODO: Update link to the formal documentation -->
+
+If the workspace is not trusted, some features that may met malicious are restricted. You can use only a basic Marp preview.
+
+#### Enable HTML in Marp Markdown
+
+You can enable previsualization of HTML code within Marp Markdown with the `markdown.marp.enableHtml` option.
+
+This feature is disabled as a default because it could allow script injection from untrusted Markdown files. Use with caution.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ If the workspace is not trusted, you can use only a basic Marp preview.
 
 You can enable previsualization of HTML code within Marp Markdown with the `markdown.marp.enableHtml` option.
 
-This feature is disabled as a default because it could allow script injection from untrusted Markdown files. Use with caution.
+It could allow script injection from untrusted Markdown files. Thus, this feature is disabled as a default and will be _always ignored in the untrusted workspace_. Use with caution.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ It also can toggle by opening the quick picker from toolbar icon <img src="https
 
 Marp for VS Code can preview your Marp Markdown with the same way as [a native Markdown preview](https://code.visualstudio.com/docs/languages/markdown#_markdown-preview).
 
-### Export slide deck to HTML, PDF, PPTX, and image
+### Export slide deck to HTML, PDF, PPTX, and image :shield:
 
 We have integrated [Marp CLI][marp-cli] to export your deck into several formats.
 
@@ -72,7 +72,7 @@ Default file type can choose by `markdown.marp.exportType` preference.
 
 > ⚠️ Export except HTML requires to install any one of [Google Chrome](https://www.google.com/chrome/), [Chromium](https://www.chromium.org/), or [Microsoft Edge](https://www.microsoft.com/edge). You may also specify the custom path for Chrome / Chromium-based browser by preference `markdown.marp.chromePath`.
 
-### Use custom theme
+### Use custom theme CSS :shield:
 
 You can register and use [custom theme CSS for Marpit](https://marpit.marp.app/theme-css) / [Marp Core](https://github.com/marp-team/marp-core/tree/main/themes#readme) by setting `markdown.marp.themes`, that includes remote URLs, or relative paths to local files in the current workspace.
 
@@ -137,11 +137,15 @@ You can fold the content of slide in editor while editing Marp Markdown.
 
 ### Security
 
-#### [Workspace Trust](https://github.com/microsoft/vscode/issues/106488) <!-- TODO: Update link to the formal documentation -->
+#### [Workspace Trust](https://github.com/microsoft/vscode/issues/106488)
 
-If the workspace is not trusted, some features that may met malicious are restricted. You can use only a basic Marp preview.
+<!-- TODO: Update link to the formal documentation -->
 
-#### Enable HTML in Marp Markdown
+Some features that may met malicious are restricted in the untrusted workspace (marked by the shield icon :shield: in this documentation).
+
+If the workspace is not trusted, you can use only a basic Marp preview.
+
+#### Enable HTML in Marp Markdown :shield:
 
 You can enable previsualization of HTML code within Marp Markdown with the `markdown.marp.enableHtml` option.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/jest": "^26.0.23",
         "@types/lodash.debounce": "^4.0.6",
         "@types/markdown-it": "^12.0.1",
-        "@types/vscode": "~1.52.0",
+        "@types/vscode": "~1.56.0",
         "@typescript-eslint/eslint-plugin": "^4.23.0",
         "@typescript-eslint/parser": "^4.23.0",
         "bufferutil": "^4.0.3",
@@ -2663,9 +2663,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
-      "integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.56.0.tgz",
+      "integrity": "sha512-Q5VmQxOx+L1Y6lIJiGcJzwcyV3pQo/eiW8P+7sNLhFI16tJCwtua2DLjHRcpjbCLNVYpQM73kzfFo1Z0HyP9eQ==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -17958,9 +17958,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.52.0.tgz",
-      "integrity": "sha512-Kt3bvWzAvvF/WH9YEcrCICDp0Z7aHhJGhLJ1BxeyNP6yRjonWqWnAIh35/pXAjswAnWOABrYlF7SwXR9+1nnLA==",
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.56.0.tgz",
+      "integrity": "sha512-Q5VmQxOx+L1Y6lIJiGcJzwcyV3pQo/eiW8P+7sNLhFI16tJCwtua2DLjHRcpjbCLNVYpQM73kzfFo1Z0HyP9eQ==",
       "dev": true
     },
     "@types/yargs": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
       "supported": "limited",
       "description": "Required for exporting Markdown, and using themes configured in the workspace.",
       "restrictedConfigurations": [
+        "markdown.marp.enableHtml",
         "markdown.marp.themes"
       ]
     },

--- a/package.json
+++ b/package.json
@@ -165,12 +165,6 @@
       "./style.css"
     ],
     "menus": {
-      "commandPalette": [
-        {
-          "command": "markdown.marp.export",
-          "when": "isWorkspaceTrusted"
-        }
-      ],
       "editor/title": [
         {
           "command": "markdown.marp.showQuickPick",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "https://github.com/marp-team/marp-vscode"
   },
   "engines": {
-    "vscode": "^1.52.0"
+    "vscode": "^1.56.0"
   },
   "main": "./lib/extension.js",
   "icon": "images/icon.png",
@@ -45,6 +45,13 @@
     "onCommand:markdown.marp.toggleMarpPreview"
   ],
   "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": "limited",
+      "description": "Required for exporting Markdown, and using themes configured in the workspace.",
+      "restrictedConfigurations": [
+        "markdown.marp.themes"
+      ]
+    },
     "virtualWorkspaces": true
   },
   "contributes": {
@@ -158,6 +165,12 @@
       "./style.css"
     ],
     "menus": {
+      "commandPalette": [
+        {
+          "command": "markdown.marp.export",
+          "when": "isWorkspaceTrusted"
+        }
+      ],
       "editor/title": [
         {
           "command": "markdown.marp.showQuickPick",
@@ -217,7 +230,7 @@
     "@types/jest": "^26.0.23",
     "@types/lodash.debounce": "^4.0.6",
     "@types/markdown-it": "^12.0.1",
-    "@types/vscode": "~1.52.0",
+    "@types/vscode": "~1.56.0",
     "@typescript-eslint/eslint-plugin": "^4.23.0",
     "@typescript-eslint/parser": "^4.23.0",
     "bufferutil": "^4.0.3",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
         "markdown.marp.enableHtml": {
           "type": "boolean",
           "default": false,
-          "description": "Enables all HTML elements in Marp Markdown."
+          "description": "Enables all HTML elements in Marp Markdown. This setting is working only in the trusted workspace."
         },
         "markdown.marp.exportType": {
           "type": "string",

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -153,6 +153,7 @@ export const workspace = {
   onDidChangeConfiguration: jest.fn(),
   onDidChangeTextDocument: jest.fn(),
   onDidCloseTextDocument: jest.fn(),
+  onDidGrantWorkspaceTrust: jest.fn(),
   textDocuments: [] as any,
 
   _setConfiguration: (conf: MockedConf = {}) => {

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -37,6 +37,11 @@ export class CodeActionKind {
   constructor(readonly value: string) {}
 }
 
+export enum CodeActionTriggerKind {
+  Invoke = 1,
+  Automatic = 2,
+}
+
 export class Diagnostic {
   code?: string
   source?: string
@@ -142,6 +147,9 @@ export const workspace = {
     ),
   })),
   getWorkspaceFolder: jest.fn(),
+  get isTrusted() {
+    return true
+  },
   onDidChangeConfiguration: jest.fn(),
   onDidChangeTextDocument: jest.fn(),
   onDidCloseTextDocument: jest.fn(),

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -1,5 +1,6 @@
 import path from 'path'
 import {
+  commands,
   env,
   ProgressLocation,
   TextDocument,
@@ -43,6 +44,7 @@ const descriptions = {
 }
 
 export const ITEM_CONTINUE_TO_EXPORT = 'Continue to export...'
+export const ITEM_MANAGE_WORKSPACE_TRUST = 'Manage Workspace Trust...'
 
 export const command = 'markdown.marp.export'
 
@@ -149,6 +151,19 @@ export const saveDialog = async (document: TextDocument) => {
 }
 
 export default async function exportCommand() {
+  if (!workspace.isTrusted) {
+    const acted = await window.showErrorMessage(
+      'Export command cannot run in untrusted workspace.',
+      ITEM_MANAGE_WORKSPACE_TRUST
+    )
+
+    if (acted === ITEM_MANAGE_WORKSPACE_TRUST) {
+      commands.executeCommand('workbench.action.manageTrust')
+    }
+
+    return
+  }
+
   const activeEditor = window.activeTextEditor
 
   if (activeEditor) {

--- a/src/commands/show-quick-pick.test.ts
+++ b/src/commands/show-quick-pick.test.ts
@@ -1,4 +1,4 @@
-import { commands, window } from 'vscode'
+import { commands, window, workspace } from 'vscode'
 import showQuickPick, { cmdSymbol } from './show-quick-pick'
 
 jest.mock('vscode')
@@ -25,5 +25,23 @@ describe('showQuickPick command', () => {
 
     await showQuickPick()
     expect(commands.executeCommand).toHaveBeenCalledWith('example.command')
+  })
+
+  describe('when the current workspace is untrusted', () => {
+    beforeEach(() => {
+      jest.spyOn(workspace, 'isTrusted', 'get').mockImplementation(() => false)
+    })
+
+    it('shows quick pick with restricted items that have shield icon', async () => {
+      const expectedItem = expect.objectContaining({
+        description: expect.stringContaining('$(shield)'),
+      })
+
+      await showQuickPick()
+      expect(window.showQuickPick).toHaveBeenCalledWith(
+        expect.arrayContaining([expectedItem]),
+        expect.anything()
+      )
+    })
   })
 })

--- a/src/commands/show-quick-pick.ts
+++ b/src/commands/show-quick-pick.ts
@@ -1,4 +1,4 @@
-import { commands, QuickPickItem, window } from 'vscode'
+import { commands, QuickPickItem, window, workspace } from 'vscode'
 import { contributes } from '../../package.json'
 import { command as exportCommand } from './export'
 import { command as openExtensionSettingsCommand } from './open-extension-settings'
@@ -28,11 +28,23 @@ availableCommands.push({
 
 export const command = 'markdown.marp.showQuickPick'
 
+const isTrustedCommand = (cmd: string) => {
+  if (!workspace.isTrusted && cmd === exportCommand) return false
+  return true
+}
+
 export default async function showQuickPick() {
-  const command = await window.showQuickPick(availableCommands, {
-    matchOnDescription: true,
-    placeHolder: 'Select available command in Marp for VS Code...',
-  })
+  const command = await window.showQuickPick(
+    availableCommands.map((cmd) =>
+      isTrustedCommand(cmd[cmdSymbol])
+        ? cmd
+        : { ...cmd, description: `${cmd.description} $(shield)` }
+    ),
+    {
+      matchOnDescription: true,
+      placeHolder: 'Select available command in Marp for VS Code...',
+    }
+  )
 
   if (command?.[cmdSymbol]) {
     await commands.executeCommand(command[cmdSymbol])

--- a/src/diagnostics/deprecated-dollar-prefix.test.ts
+++ b/src/diagnostics/deprecated-dollar-prefix.test.ts
@@ -2,6 +2,7 @@ import dedent from 'dedent'
 import {
   CancellationToken,
   CodeAction,
+  CodeActionTriggerKind,
   CodeActionKind,
   Diagnostic,
   DiagnosticSeverity,
@@ -164,7 +165,7 @@ describe('[Diagnostics rule] Deprecated dollar prefix', () => {
         const codeActions = new rule.RemoveDollarPrefix().provideCodeActions(
           document,
           dummyRange,
-          { diagnostics },
+          { diagnostics, triggerKind: CodeActionTriggerKind.Invoke },
           dummyToken
         )
 
@@ -192,7 +193,7 @@ describe('[Diagnostics rule] Deprecated dollar prefix', () => {
         const codeActions = new rule.RemoveDollarPrefix().provideCodeActions(
           document,
           dummyRange,
-          { diagnostics },
+          { diagnostics, triggerKind: CodeActionTriggerKind.Invoke },
           dummyToken
         )
 

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -186,6 +186,21 @@ describe('#extendMarkdownIt', () => {
         const html = md().render(marpMd('<b>Hi</b>'))
         expect(html).toContain('<b>Hi</b>')
       })
+
+      describe('when the current workspace is untrusted', () => {
+        beforeEach(() => {
+          jest
+            .spyOn(workspace, 'isTrusted', 'get')
+            .mockImplementation(() => false)
+        })
+
+        it('does not render HTML elements even if enabled', () => {
+          setConfiguration({ 'markdown.marp.enableHtml': true })
+
+          const html = md().render(marpMd('<b>Hi</b>'))
+          expect(html).not.toContain('<b>Hi</b>')
+        })
+      })
     })
 
     describe('markdown.marp.mathTypesetting', () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,11 @@ const shouldRefreshConfs = [
   'markdown.preview.typographer',
 ]
 
+const applyRefreshedConfiguration = () => {
+  clearMarpCoreOptionCache()
+  commands.executeCommand('markdown.preview.refresh')
+}
+
 export const marpVscode = Symbol('marp-vscode')
 
 export function extendMarkdownIt(md: any) {
@@ -134,10 +139,10 @@ export const activate = ({ subscriptions }: ExtensionContext) => {
     themes,
     workspace.onDidChangeConfiguration((e) => {
       if (shouldRefreshConfs.some((c) => e.affectsConfiguration(c))) {
-        clearMarpCoreOptionCache()
-        commands.executeCommand('markdown.preview.refresh')
+        applyRefreshedConfiguration()
       }
-    })
+    }),
+    workspace.onDidGrantWorkspaceTrust(applyRefreshedConfiguration)
   )
 
   return { extendMarkdownIt }

--- a/src/option.test.ts
+++ b/src/option.test.ts
@@ -111,5 +111,18 @@ describe('Option', () => {
         }
       })
     })
+
+    describe('when the current workspace is untrusted', () => {
+      beforeEach(() => {
+        jest
+          .spyOn(workspace, 'isTrusted', 'get')
+          .mockImplementation(() => false)
+      })
+
+      it('ignores potentially malicious options', async () => {
+        setConfiguration({ 'markdown.marp.enableHtml': true })
+        expect((await subject({ uri: untitledUri })).html).toBeUndefined()
+      })
+    })
   })
 })

--- a/src/option.ts
+++ b/src/option.ts
@@ -27,13 +27,16 @@ const breaks = (inheritedValue: boolean): boolean => {
   }
 }
 
+const enableHtml = () =>
+  marpConfiguration().get<boolean>('enableHtml') && workspace.isTrusted
+
 export const marpCoreOptionForPreview = (
   baseOption: Options & MarpOptions
 ): MarpOptions => {
   if (!cachedPreviewOption) {
     cachedPreviewOption = {
       container: { tag: 'div', id: 'marp-vscode' },
-      html: marpConfiguration().get<boolean>('enableHtml') || undefined,
+      html: enableHtml() || undefined,
       markdown: {
         breaks: breaks(!!baseOption.breaks),
         typographer: baseOption.typographer,
@@ -54,7 +57,7 @@ export const marpCoreOptionForCLI = async (
 
   const baseOpts = {
     allowLocalFiles,
-    html: marpConfiguration().get<boolean>('enableHtml') || undefined,
+    html: enableHtml() || undefined,
     options: {
       markdown: {
         breaks: breaks(!!confMdPreview.get<boolean>('breaks')),


### PR DESCRIPTION
Related: #194

## Background

Based on [a vulnerabled classic Marp](https://yhatt.github.io/marp/), _we always have importance to security._

Our core features like export and theme CSS support may read potentially dangerous to user. For example:

- Execute malicious script contained in Markdown with user-land Chromium, while exporting PDF.
- Track a usage through a network request triggered by the remote theme set by workspace.

Markdown preview (provided by VS Code) has already [a security layer](https://code.visualstudio.com/docs/languages/markdown#_markdown-preview-security), but extended features by Marp are not. We have not adopted a potentially dangerous feature even if wanted by several users (such as #123).

VS Code team is working for the trusted workspace, the security mechanism for preventing malicious workspace. Marp should follow it to save users from some maliciouses.

## Behavior

If enabled trusted workspace `security.workspace.trust.enabled`:

- All of features will work well in the trusted workspace as usual.
- In untrusted workspace, we will only enable features about basic Markdown preview. 
  - `markdown.marp.export` command will not work. Instead show a prompt for checking workspace trust setting to user.  
    
    ![](https://user-images.githubusercontent.com/3993388/118054812-ed866500-b3c1-11eb-8764-6993a7df8860.png)
  - `markdown.marp.themes` configuration by the workspace will ignore, as same as [VS Code's Markdown preview `markdown.styles`](https://github.com/microsoft/vscode/blob/11a8c4b4bc72d01620404847452073360204acd2/extensions/markdown-language-features/package.json#L37-L39). But accept if configured as user setting.
  - In the untrusted workspace, `markdown.marp.enableHtml` will be recognized as always `false`.
  - In quick pick menu, the export command will mark by the shield icon.
    
    ![](https://user-images.githubusercontent.com/3993388/118054938-26bed500-b3c2-11eb-86ac-93eea6161043.png)

