### PR TITLE
Mark overloaded global directive in the subsequent definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - VS Code >= 1.56 is now required ([#231](https://github.com/marp-team/marp-vscode/pull/231))
 
+### Added
+
+- Mark overloaded global directive in the subsequent definition ([#232](https://github.com/marp-team/marp-vscode/pull/232))
+
 ### Changed
 
 - Support [Workspace Trust](https://code.visualstudio.com/updates/v1_56#_workspace-trust): Restrict some features in the untrusted workspace ([#231](https://github.com/marp-team/marp-vscode/pull/231))

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "stylelint-config-standard": "^22.0.0",
         "ts-jest": "^26.5.6",
         "tslib": "^2.2.0",
+        "typed-emitter": "^1.3.1",
         "typescript": "^4.2.4",
         "unified": "^9.2.1",
         "unist-util-visit": "^3.1.0",
@@ -61,7 +62,7 @@
         "yaml": "^1.10.2"
       },
       "engines": {
-        "vscode": "^1.52.0"
+        "vscode": "^1.56.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -14879,6 +14880,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typed-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-1.3.1.tgz",
+      "integrity": "sha512-2h7utWyXgd2R2u2IuL8B4yu1gqMxbgUj2VS/MGVbFhEVQNJKXoQQoS5CBMh+eW31zFeSmDfEQ3qQf4xy5SlPVQ==",
+      "dev": true
+    },
     "node_modules/typed-rest-client": {
       "version": "1.8.4",
       "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.4.tgz",
@@ -27307,6 +27314,12 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typed-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-1.3.1.tgz",
+      "integrity": "sha512-2h7utWyXgd2R2u2IuL8B4yu1gqMxbgUj2VS/MGVbFhEVQNJKXoQQoS5CBMh+eW31zFeSmDfEQ3qQf4xy5SlPVQ==",
+      "dev": true
     },
     "typed-rest-client": {
       "version": "1.8.4",

--- a/package.json
+++ b/package.json
@@ -256,6 +256,7 @@
     "stylelint-config-standard": "^22.0.0",
     "ts-jest": "^26.5.6",
     "tslib": "^2.2.0",
+    "typed-emitter": "^1.3.1",
     "typescript": "^4.2.4",
     "unified": "^9.2.1",
     "unist-util-visit": "^3.1.0",

--- a/src/diagnostics/deprecated-dollar-prefix.test.ts
+++ b/src/diagnostics/deprecated-dollar-prefix.test.ts
@@ -12,6 +12,7 @@ import {
   TextDocument,
   WorkspaceEdit,
 } from 'vscode'
+import { DirectiveParser } from '../directive-parser'
 import * as rule from './deprecated-dollar-prefix'
 
 jest.mock('vscode')
@@ -30,9 +31,12 @@ const doc = (text: string): TextDocument =>
 
 describe('[Diagnostics rule] Deprecated dollar prefix', () => {
   const register = (doc: TextDocument): Diagnostic[] => {
+    const parser = new DirectiveParser()
     const diagnostics: Diagnostic[] = []
-    rule.register(doc, diagnostics)
 
+    rule.register(doc, parser, diagnostics)
+
+    parser.parse(doc)
     return diagnostics
   }
 

--- a/src/diagnostics/index.test.ts
+++ b/src/diagnostics/index.test.ts
@@ -1,10 +1,13 @@
 import { window, TextDocument } from 'vscode'
+import { DirectiveParser } from '../directive-parser'
 import * as deprecatedDollarPrefix from './deprecated-dollar-prefix'
+import * as overloadingGlobalDirective from './overloading-global-directive'
 import * as diagnostics from './index'
 
 jest.mock('lodash.debounce')
 jest.mock('vscode')
 jest.mock('./deprecated-dollar-prefix')
+jest.mock('./overloading-global-directive')
 
 const plainTextDocMock: TextDocument = {
   languageId: 'plaintext',
@@ -60,6 +63,7 @@ describe('Diagnostics', () => {
 
     it('sets diagnostics when passed markdown document with marp frontmatter', () => {
       const arr = expect.any(Array)
+      const parser = expect.any(DirectiveParser)
       const doc = mdDocMock('---\nmarp: true\n---\n\n# Hello')
       diagnostics.refresh(doc)
 
@@ -67,7 +71,16 @@ describe('Diagnostics', () => {
       expect(diagnostics.collection.set).toHaveBeenCalledWith('/markdown', arr)
 
       // Rules
-      expect(deprecatedDollarPrefix.register).toHaveBeenCalledWith(doc, arr)
+      expect(deprecatedDollarPrefix.register).toHaveBeenCalledWith(
+        doc,
+        parser,
+        arr
+      )
+      expect(overloadingGlobalDirective.register).toHaveBeenCalledWith(
+        doc,
+        parser,
+        arr
+      )
     })
   })
 })

--- a/src/diagnostics/index.ts
+++ b/src/diagnostics/index.ts
@@ -7,15 +7,21 @@ import {
   window,
   workspace,
 } from 'vscode'
+import { DirectiveParser } from '../directive-parser'
 import { detectMarpDocument } from '../utils'
 import * as deprecatedDollarPrefix from './deprecated-dollar-prefix'
+import * as overloadingGlobalDirective from './overloading-global-directive'
 
 export const collection = languages.createDiagnosticCollection('marp-vscode')
 
 const setDiagnostics = lodashDebounce((doc: TextDocument) => {
+  const directiveParser = new DirectiveParser()
   const diagnostics: Diagnostic[] = []
 
-  deprecatedDollarPrefix.register(doc, diagnostics)
+  deprecatedDollarPrefix.register(doc, directiveParser, diagnostics)
+  overloadingGlobalDirective.register(doc, directiveParser, diagnostics)
+
+  directiveParser.parse(doc)
 
   collection.set(doc.uri, diagnostics)
 }, 500)

--- a/src/diagnostics/overloading-global-directive.test.ts
+++ b/src/diagnostics/overloading-global-directive.test.ts
@@ -1,0 +1,120 @@
+import dedent from 'dedent'
+import {
+  Diagnostic,
+  DiagnosticSeverity,
+  Position,
+  Range,
+  TextDocument,
+} from 'vscode'
+import { DirectiveParser } from '../directive-parser'
+import * as rule from './overloading-global-directive'
+
+jest.mock('vscode')
+
+const doc = (text: string): TextDocument =>
+  ({
+    getText: () => text,
+    positionAt: (offset: number) => {
+      const lines = text.slice(0, offset).split('\n')
+
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      return new Position(lines.length - 1, lines.pop()!.length)
+    },
+    uri: '/test/document',
+  } as any)
+
+describe('[Diagnostics rule] Overloading global directive', () => {
+  const register = (doc: TextDocument): Diagnostic[] => {
+    const parser = new DirectiveParser()
+    const diagnostics: Diagnostic[] = []
+
+    rule.register(doc, parser, diagnostics)
+
+    parser.parse(doc)
+    return diagnostics
+  }
+
+  describe('#register', () => {
+    it('adds diagnostics when passed with overloaded global directive', () => {
+      const basic = register(
+        doc(dedent`
+          ---
+          theme: default
+          size: 4:3
+          ---
+
+          <!-- theme: gaia -->
+        `)
+      )
+      expect(basic).toHaveLength(1)
+
+      const [$theme] = basic
+      expect($theme).toBeInstanceOf(Diagnostic)
+      expect($theme.code).toBe(rule.code)
+      expect($theme.source).toBe('marp-vscode')
+      expect($theme.severity).toBe(DiagnosticSeverity.Warning)
+      expect($theme.range).toStrictEqual(
+        new Range(new Position(1, 0), new Position(1, 14))
+      )
+    })
+
+    it('adds diagnostics when there are multiple overloaded global directives', () => {
+      const multiple = register(
+        doc(dedent`
+          ---
+          theme: default
+          ---
+
+          <!--
+          theme: |
+            unknown
+          -->
+
+          <!-- theme: gaia -->
+        `)
+      )
+      expect(multiple).toHaveLength(2)
+
+      for (const diagnostic of multiple) {
+        expect(diagnostic).toBeInstanceOf(Diagnostic)
+      }
+
+      const [$default, $unknown] = multiple
+      expect($default.range).toStrictEqual(
+        new Range(new Position(1, 0), new Position(1, 14))
+      )
+      expect($unknown.range).toStrictEqual(
+        new Range(new Position(5, 0), new Position(6, 9))
+      )
+    })
+
+    it('does not add diagnostics when overloaded local directives', () =>
+      expect(
+        register(
+          doc(dedent`
+            ---
+            paginate: true
+            _paginate: false
+            ---
+
+            <!--
+            paginate: false
+            -->
+          `)
+        )
+      ).toHaveLength(0))
+
+    it('does not add diagnostics when overloaded unknown directives', () =>
+      expect(
+        register(
+          doc(dedent`
+            ---
+            unknown: true
+            ---
+
+            <!-- unknown: false -->
+          `)
+        )
+      ).toHaveLength(0))
+  })
+})

--- a/src/diagnostics/overloading-global-directive.ts
+++ b/src/diagnostics/overloading-global-directive.ts
@@ -1,0 +1,63 @@
+import { Diagnostic, DiagnosticSeverity, Range, TextDocument } from 'vscode'
+import { Pair } from 'yaml/types'
+import { DirectiveParser, DirectiveType } from '../directive-parser'
+
+interface ParsedGlobalDirective {
+  item: Pair
+  range: Range
+}
+
+export const code = 'overloading-global-directive'
+
+export function register(
+  doc: TextDocument,
+  directiveParser: DirectiveParser,
+  diagnostics: Diagnostic[]
+) {
+  const parsedGlobalDirectives = new Map<string, ParsedGlobalDirective[]>()
+
+  directiveParser.on('startParse', () => {
+    parsedGlobalDirectives.clear()
+  })
+
+  directiveParser.on('directive', ({ item, offset, info }) => {
+    if (info?.type === DirectiveType.Global) {
+      const [start] = item.key.range
+      const [, end] = item.value.range
+
+      parsedGlobalDirectives.set(info.name, [
+        ...(parsedGlobalDirectives.get(info.name) ?? []),
+        {
+          item,
+          range: new Range(
+            doc.positionAt(start + offset),
+            doc.positionAt(end + offset)
+          ),
+        },
+      ])
+    }
+  })
+
+  directiveParser.on('endParse', () => {
+    for (const key of parsedGlobalDirectives.keys()) {
+      const parsed = parsedGlobalDirectives.get(key) ?? []
+
+      if (parsed.length >= 2) {
+        const lastIdx = parsed.length - 1
+
+        for (let i = 0; i < lastIdx; i += 1) {
+          const diagnostic = new Diagnostic(
+            parsed[i].range,
+            `The ${key} global directive has overloaded the subsequent definition.`,
+            DiagnosticSeverity.Warning
+          )
+
+          diagnostic.source = 'marp-vscode'
+          diagnostic.code = code
+
+          diagnostics.push(diagnostic)
+        }
+      }
+    }
+  })
+}

--- a/src/diagnostics/parser.ts
+++ b/src/diagnostics/parser.ts
@@ -1,9 +1,0 @@
-import rehypeParse from 'rehype-parse'
-import remarkParse from 'remark-parse'
-import unified from 'unified'
-import yaml from 'yaml'
-
-export const parseHtml = unified().use(rehypeParse).parse
-export const parseMd = unified().use(remarkParse).parse
-export const parseYaml = (yamlBody: string) =>
-  yaml.parseDocument(yamlBody, { schema: 'failsafe' })

--- a/src/directive-parser.ts
+++ b/src/directive-parser.ts
@@ -1,0 +1,294 @@
+import { EventEmitter } from 'events'
+import rehypeParse from 'rehype-parse'
+import remarkParse from 'remark-parse'
+import TypedEmitter from 'typed-emitter'
+import unified from 'unified'
+import { visit } from 'unist-util-visit'
+import { TextDocument } from 'vscode'
+import yaml from 'yaml'
+import { Pair, YAMLMap } from 'yaml/types'
+import { frontMatterRegex } from './utils'
+
+export const parseHtml = unified().use(rehypeParse).parse
+export const parseMd = unified().use(remarkParse).parse
+export const parseYaml = (yamlBody: string) =>
+  yaml.parseDocument(yamlBody, { schema: 'failsafe' })
+
+export enum DirectiveType {
+  Global = 'Global',
+  Local = 'Local',
+}
+
+export enum DirectiveDefinedIn {
+  FrontMatter = 'frontMatter',
+  Comment = 'comment',
+}
+
+const directiveAlwaysAllowed = [
+  DirectiveDefinedIn.FrontMatter,
+  DirectiveDefinedIn.Comment,
+] as const
+
+export enum DirectiveProvidedBy {
+  Marpit = 'marpit',
+  MarpCore = 'marp-core',
+  MarpCLI = 'marp-cli',
+  MarpVSCode = 'marp-vscode',
+}
+
+interface DirectiveInfoBase {
+  allowed: readonly DirectiveDefinedIn[]
+  providedBy: DirectiveProvidedBy
+  description: string
+  name: string
+  type: DirectiveType
+}
+
+type GlobalDirectiveInfo = DirectiveInfoBase & {
+  scoped?: never
+  type: DirectiveType.Global
+}
+
+type LocalDirectiveInfo = DirectiveInfoBase & {
+  scoped?: boolean
+  type: DirectiveType.Local
+}
+
+export type DirectiveInfo = GlobalDirectiveInfo | LocalDirectiveInfo
+
+export interface DirectiveEventHandler {
+  info?: DirectiveInfo
+  item: Pair
+  offset: number
+}
+
+interface DirectiveParserEvents {
+  directive: (event: DirectiveEventHandler) => void
+  startParse: (event: { document: TextDocument }) => void
+  endParse: (event: { document: TextDocument }) => void
+}
+
+export class DirectiveParser extends (EventEmitter as new () => TypedEmitter<DirectiveParserEvents>) {
+  static builtinDirectives: readonly DirectiveInfo[] = [
+    // Marp for VS Code
+    {
+      name: 'marp',
+      description:
+        'Set whether or not enable Marp preview in VS Code extension.',
+      allowed: [DirectiveDefinedIn.FrontMatter],
+      providedBy: DirectiveProvidedBy.MarpVSCode,
+      type: DirectiveType.Global,
+    },
+
+    // Marpit global directives
+    {
+      name: 'theme',
+      description: 'Specify a theme name of the slide deck.',
+      allowed: directiveAlwaysAllowed,
+      providedBy: DirectiveProvidedBy.Marpit,
+      type: DirectiveType.Global,
+    },
+    {
+      name: 'style',
+      description: 'Specify CSS for tweaking theme.',
+      allowed: directiveAlwaysAllowed,
+      providedBy: DirectiveProvidedBy.Marpit,
+      type: DirectiveType.Global,
+    },
+    {
+      name: 'headingDivider',
+      description: 'Specify heading divider option.',
+      allowed: directiveAlwaysAllowed,
+      providedBy: DirectiveProvidedBy.Marpit,
+      type: DirectiveType.Global,
+    },
+
+    // Marpit local directives
+    {
+      name: 'paginate',
+      description: 'Show page number on the slide if set `true`.',
+      allowed: directiveAlwaysAllowed,
+      providedBy: DirectiveProvidedBy.Marpit,
+      type: DirectiveType.Local,
+    },
+    {
+      name: 'header',
+      description: 'Specify the content of slide header.',
+      allowed: directiveAlwaysAllowed,
+      providedBy: DirectiveProvidedBy.Marpit,
+      type: DirectiveType.Local,
+    },
+    {
+      name: 'footer',
+      description: 'Specify the content of slide footer.',
+      allowed: directiveAlwaysAllowed,
+      providedBy: DirectiveProvidedBy.Marpit,
+      type: DirectiveType.Local,
+    },
+    {
+      name: 'class',
+      description:
+        "Specify HTML's `class` attribute for the slide element <section>.",
+      allowed: directiveAlwaysAllowed,
+      providedBy: DirectiveProvidedBy.Marpit,
+      type: DirectiveType.Local,
+    },
+    {
+      name: 'backgroundColor',
+      description: 'Setting `background-color` style of the slide.',
+      allowed: directiveAlwaysAllowed,
+      providedBy: DirectiveProvidedBy.Marpit,
+      type: DirectiveType.Local,
+    },
+    {
+      name: 'backgroundImage',
+      description: 'Setting `background-image` style of the slide.',
+      allowed: directiveAlwaysAllowed,
+      providedBy: DirectiveProvidedBy.Marpit,
+      type: DirectiveType.Local,
+    },
+    {
+      name: 'backgroundPosition',
+      description: 'Setting `background-position` style of the slide.',
+      allowed: directiveAlwaysAllowed,
+      providedBy: DirectiveProvidedBy.Marpit,
+      type: DirectiveType.Local,
+    },
+    {
+      name: 'backgroundRepeat',
+      description: 'Setting `background-repeat` style of the slide.',
+      allowed: directiveAlwaysAllowed,
+      providedBy: DirectiveProvidedBy.Marpit,
+      type: DirectiveType.Local,
+    },
+    {
+      name: 'backgroundSize',
+      description: 'Setting `background-size` style of the slide.',
+      allowed: directiveAlwaysAllowed,
+      providedBy: DirectiveProvidedBy.Marpit,
+      type: DirectiveType.Local,
+    },
+    {
+      name: 'color',
+      description: 'Setting `color` style of the slide.',
+      allowed: directiveAlwaysAllowed,
+      providedBy: DirectiveProvidedBy.Marpit,
+      type: DirectiveType.Local,
+    },
+
+    // Marp Core extension
+    {
+      name: 'size',
+      description: 'Choose the slide size preset provided by theme.',
+      allowed: directiveAlwaysAllowed,
+      providedBy: DirectiveProvidedBy.MarpCore,
+      type: DirectiveType.Global,
+    },
+
+    // Marp CLI meta options
+    {
+      name: 'title',
+      description: 'Define title of the slide deck.',
+      allowed: directiveAlwaysAllowed,
+      providedBy: DirectiveProvidedBy.MarpCLI,
+      type: DirectiveType.Global,
+    },
+    {
+      name: 'description',
+      description: 'Define description of the slide deck.',
+      allowed: directiveAlwaysAllowed,
+      providedBy: DirectiveProvidedBy.MarpCLI,
+      type: DirectiveType.Global,
+    },
+    {
+      name: 'url',
+      description: 'Define canonical URL to the slide deck.',
+      allowed: directiveAlwaysAllowed,
+      providedBy: DirectiveProvidedBy.MarpCLI,
+      type: DirectiveType.Global,
+    },
+    {
+      name: 'image',
+      description: 'Define Open Graph image URL.',
+      allowed: directiveAlwaysAllowed,
+      providedBy: DirectiveProvidedBy.MarpCLI,
+      type: DirectiveType.Global,
+    },
+  ]
+
+  directives: DirectiveInfo[] = [...DirectiveParser.builtinDirectives]
+
+  parse(doc: TextDocument) {
+    this.emit('startParse', { document: doc })
+
+    let markdown = doc.getText()
+    let index = 0
+
+    const detectDirectives = (
+      text: string,
+      offset: number,
+      definedIn = DirectiveDefinedIn.Comment
+    ) => {
+      const { contents, errors } = parseYaml(text)
+
+      if (errors.length === 0 && contents?.['items']) {
+        for (const item of (contents as YAMLMap).items) {
+          if (item.type === 'PAIR') {
+            let scoped: boolean | undefined = undefined
+
+            const directiveInfo = this.directives.find((d) => {
+              if (!d.allowed.includes(definedIn)) return false
+
+              if (item.key.value === d.name) return true
+
+              if (
+                d.type === DirectiveType.Local &&
+                item.key.value === `_${d.name}`
+              ) {
+                scoped = true
+                return true
+              }
+
+              return false
+            })
+
+            this.emit('directive', {
+              info: directiveInfo ? { ...directiveInfo, scoped } : undefined,
+              item,
+              offset,
+            })
+          }
+        }
+      }
+    }
+
+    // Front-matter
+    const fmMatched = markdown.match(frontMatterRegex)
+
+    if (fmMatched?.index === 0) {
+      const [, open, body, close] = fmMatched
+      detectDirectives(body, open.length, DirectiveDefinedIn.FrontMatter)
+
+      index = open.length + body.length + close.length
+      markdown = markdown.slice(index)
+    }
+
+    // HTML comments
+    visit(parseMd(markdown), 'html', (n: any) =>
+      visit(parseHtml(n.value), 'comment', (c: any) => {
+        const trimmedLeft = c.value.replace(/^-*\s*/, '')
+
+        detectDirectives(
+          trimmedLeft.replace(/\s*-*$/, ''),
+          index +
+            n.position.start.offset +
+            c.position.start.offset +
+            4 +
+            (c.value.length - trimmedLeft.length)
+        )
+      })
+    )
+
+    this.emit('endParse', { document: doc })
+  }
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import { TextDocument, workspace } from 'vscode'
 
-export const frontMatterRegex = /^(-{3,}\s*$\n)([\s\S]*?)^(\s*-{3})/m
+export const frontMatterRegex = /^(-{3,}\s*$\n)([\s\S]*?)^(\s*[-.]{3})/m
 
 export const marpDirectiveRegex = /^(marp\s*: +)(.*)\s*$/m
 


### PR DESCRIPTION
This is offshoot of working for directive auto-completion (#158).

The new diagnostic `overloading-global-directive` will notify overloaded global directive by the subsequent definition. 

![](https://user-images.githubusercontent.com/3993388/118096232-0a478a80-b40c-11eb-9064-6c80fc4e76e9.png)

A slide author can notice to the duplicated definition of global directive. The marked directive should be able to remove safely.
