### PR TITLE
Add color highlight and hover help for directives

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,17 @@
     "virtualWorkspaces": true
   },
   "contributes": {
+    "colors": [
+      {
+        "id": "marp.directiveKeyForeground",
+        "description": "Forground decoration color for the key of Marp directive",
+        "defaults": {
+          "dark": "#67b8e3ff",
+          "light": "#0288d1ff",
+          "highContrast": "#67b8e3ff"
+        }
+      }
+    ],
     "commands": [
       {
         "category": "Marp",

--- a/src/diagnostics/overloading-global-directive.ts
+++ b/src/diagnostics/overloading-global-directive.ts
@@ -48,7 +48,7 @@ export function register(
         for (let i = 0; i < lastIdx; i += 1) {
           const diagnostic = new Diagnostic(
             parsed[i].range,
-            `The ${key} global directive has overloaded the subsequent definition.`,
+            `The ${key} global directive may be overloaded the subsequent definition.`,
             DiagnosticSeverity.Warning
           )
 

--- a/src/directive-parser.ts
+++ b/src/directive-parser.ts
@@ -1,17 +1,18 @@
 import { EventEmitter } from 'events'
+import dedent from 'dedent'
 import rehypeParse from 'rehype-parse'
 import remarkParse from 'remark-parse'
 import TypedEmitter from 'typed-emitter'
 import unified from 'unified'
 import { visit } from 'unist-util-visit'
-import { TextDocument } from 'vscode'
+import { MarkdownString, TextDocument } from 'vscode'
 import yaml from 'yaml'
 import { Pair, YAMLMap } from 'yaml/types'
 import { frontMatterRegex } from './utils'
 
-export const parseHtml = unified().use(rehypeParse).parse
-export const parseMd = unified().use(remarkParse).parse
-export const parseYaml = (yamlBody: string) =>
+const parseHtml = unified().use(rehypeParse).parse
+const parseMd = unified().use(remarkParse).parse
+const parseYaml = (yamlBody: string) =>
   yaml.parseDocument(yamlBody, { schema: 'failsafe' })
 
 export enum DirectiveType {
@@ -30,17 +31,19 @@ const directiveAlwaysAllowed = [
 ] as const
 
 export enum DirectiveProvidedBy {
-  Marpit = 'marpit',
-  MarpCore = 'marp-core',
-  MarpCLI = 'marp-cli',
-  MarpVSCode = 'marp-vscode',
+  Marpit = 'Marpit framework',
+  MarpCore = 'Marp Core',
+  MarpCLI = 'Marp CLI',
+  MarpVSCode = 'Marp for VS Code',
 }
 
 interface DirectiveInfoBase {
   allowed: readonly DirectiveDefinedIn[]
-  providedBy: DirectiveProvidedBy
   description: string
+  details?: string
+  markdownDescription: string | MarkdownString
   name: string
+  providedBy: DirectiveProvidedBy
   type: DirectiveType
 }
 
@@ -56,6 +59,33 @@ type LocalDirectiveInfo = DirectiveInfoBase & {
 
 export type DirectiveInfo = GlobalDirectiveInfo | LocalDirectiveInfo
 
+const createDirectiveInfo = (
+  info:
+    | Omit<GlobalDirectiveInfo, 'markdownDescription'>
+    | Omit<LocalDirectiveInfo, 'markdownDescription'>
+): Readonly<DirectiveInfo> =>
+  Object.freeze({
+    ...info,
+    get markdownDescription() {
+      const directiveText = `\`${info.name}\` [${
+        info.type
+      } directive](https://marpit.marp.app/directives?id=${info.type.toLowerCase()}-directives)${
+        info.scoped ? ' _[Scoped]_' : ''
+      }`
+
+      return new MarkdownString(
+        [
+          directiveText,
+          info.description,
+          `_Provided by ${info.providedBy}${
+            info.details ? ` ([Show more details...](${info.details}))` : ''
+          }_`,
+        ].join('\n\n---\n\n'),
+        true
+      )
+    },
+  })
+
 export interface DirectiveEventHandler {
   info?: DirectiveInfo
   item: Pair
@@ -69,151 +99,206 @@ interface DirectiveParserEvents {
 }
 
 export class DirectiveParser extends (EventEmitter as new () => TypedEmitter<DirectiveParserEvents>) {
-  static builtinDirectives: readonly DirectiveInfo[] = [
+  static builtinDirectives: readonly Readonly<DirectiveInfo>[] = [
     // Marp for VS Code
-    {
+    createDirectiveInfo({
       name: 'marp',
       description:
         'Set whether or not enable Marp preview in VS Code extension.',
       allowed: [DirectiveDefinedIn.FrontMatter],
       providedBy: DirectiveProvidedBy.MarpVSCode,
       type: DirectiveType.Global,
-    },
+      details: 'https://github.com/marp-team/marp-vscode#usage',
+    }),
 
     // Marpit global directives
-    {
+    createDirectiveInfo({
       name: 'theme',
-      description: 'Specify a theme name of the slide deck.',
+      description: dedent(`
+        Specify a theme name of the slide deck.
+
+        ## [Marp Core built-in themes](https://github.com/marp-team/marp-core/tree/main/themes)
+
+        ### \`default\`
+
+        ![](https://user-images.githubusercontent.com/3993388/48039490-53be1b80-e1b8-11e8-8179-0e6c11d285e2.png)
+
+        ### \`gaia\`
+
+        ![](https://user-images.githubusercontent.com/3993388/48039493-5456b200-e1b8-11e8-9c49-dd5d66d76c0d.png)
+
+        ### \`uncover\`
+
+        ![](https://user-images.githubusercontent.com/3993388/48039495-5456b200-e1b8-11e8-8c82-ca7f7842b34d.png)
+      `),
       allowed: directiveAlwaysAllowed,
       providedBy: DirectiveProvidedBy.Marpit,
       type: DirectiveType.Global,
-    },
-    {
+      details: 'https://marpit.marp.app/directives?id=theme',
+    }),
+    createDirectiveInfo({
       name: 'style',
-      description: 'Specify CSS for tweaking theme.',
+      description: dedent(`
+        Specify CSS for tweaking theme.
+
+        \`\`\`yaml
+        style: |
+          section {
+            background-color: #123;
+            color: #def;
+          }
+        \`\`\`
+      `),
       allowed: directiveAlwaysAllowed,
       providedBy: DirectiveProvidedBy.Marpit,
       type: DirectiveType.Global,
-    },
-    {
+      details: 'https://marpit.marp.app/directives?id=tweak-theme-style',
+    }),
+    createDirectiveInfo({
       name: 'headingDivider',
-      description: 'Specify heading divider option.',
+      description: dedent(`
+        Specify heading divider option.
+
+        You may instruct to divide slide pages automatically at before of headings. This feature is similar to [Pandoc](https://pandoc.org/)'s [\`--slide-level\` option](https://pandoc.org/MANUAL.html#structuring-the-slide-show) and [Deckset 2](https://www.deckset.com/2/)'s "Slide Dividers" option.
+
+        It have to specify heading level from 1 to 6 (e.g. \`headingDivider: 2\`), or array of them (e.g. \`headingDivider: [1, 3]\`). This feature is enabled at headings whose the level _higher than or equal to the specified value_ if in a number, and it is enabled at _only specified levels_ if in array.
+      `),
       allowed: directiveAlwaysAllowed,
       providedBy: DirectiveProvidedBy.Marpit,
       type: DirectiveType.Global,
-    },
+      details: 'https://marpit.marp.app/directives?id=heading-divider',
+    }),
 
     // Marpit local directives
-    {
+    createDirectiveInfo({
       name: 'paginate',
       description: 'Show page number on the slide if set `true`.',
       allowed: directiveAlwaysAllowed,
       providedBy: DirectiveProvidedBy.Marpit,
       type: DirectiveType.Local,
-    },
-    {
+      details: 'https://marpit.marp.app/directives?id=pagination',
+    }),
+    createDirectiveInfo({
       name: 'header',
       description: 'Specify the content of slide header.',
       allowed: directiveAlwaysAllowed,
       providedBy: DirectiveProvidedBy.Marpit,
       type: DirectiveType.Local,
-    },
-    {
+      details: 'https://marpit.marp.app/directives?id=header-and-footer',
+    }),
+    createDirectiveInfo({
       name: 'footer',
       description: 'Specify the content of slide footer.',
       allowed: directiveAlwaysAllowed,
       providedBy: DirectiveProvidedBy.Marpit,
       type: DirectiveType.Local,
-    },
-    {
+      details: 'https://marpit.marp.app/directives?id=header-and-footer',
+    }),
+    createDirectiveInfo({
       name: 'class',
       description:
-        "Specify HTML's `class` attribute for the slide element <section>.",
+        "Specify HTML's `class` attribute for the slide element `<section>`.",
       allowed: directiveAlwaysAllowed,
       providedBy: DirectiveProvidedBy.Marpit,
       type: DirectiveType.Local,
-    },
-    {
+      details: 'https://marpit.marp.app/directives?id=class',
+    }),
+    createDirectiveInfo({
       name: 'backgroundColor',
       description: 'Setting `background-color` style of the slide.',
       allowed: directiveAlwaysAllowed,
       providedBy: DirectiveProvidedBy.Marpit,
       type: DirectiveType.Local,
-    },
-    {
+      details: 'https://marpit.marp.app/directives?id=backgrounds',
+    }),
+    createDirectiveInfo({
       name: 'backgroundImage',
       description: 'Setting `background-image` style of the slide.',
       allowed: directiveAlwaysAllowed,
       providedBy: DirectiveProvidedBy.Marpit,
       type: DirectiveType.Local,
-    },
-    {
+      details: 'https://marpit.marp.app/directives?id=backgrounds',
+    }),
+    createDirectiveInfo({
       name: 'backgroundPosition',
       description: 'Setting `background-position` style of the slide.',
       allowed: directiveAlwaysAllowed,
       providedBy: DirectiveProvidedBy.Marpit,
       type: DirectiveType.Local,
-    },
-    {
+      details: 'https://marpit.marp.app/directives?id=backgrounds',
+    }),
+    createDirectiveInfo({
       name: 'backgroundRepeat',
       description: 'Setting `background-repeat` style of the slide.',
       allowed: directiveAlwaysAllowed,
       providedBy: DirectiveProvidedBy.Marpit,
       type: DirectiveType.Local,
-    },
-    {
+      details: 'https://marpit.marp.app/directives?id=backgrounds',
+    }),
+    createDirectiveInfo({
       name: 'backgroundSize',
       description: 'Setting `background-size` style of the slide.',
       allowed: directiveAlwaysAllowed,
       providedBy: DirectiveProvidedBy.Marpit,
       type: DirectiveType.Local,
-    },
-    {
+      details: 'https://marpit.marp.app/directives?id=backgrounds',
+    }),
+    createDirectiveInfo({
       name: 'color',
       description: 'Setting `color` style of the slide.',
       allowed: directiveAlwaysAllowed,
       providedBy: DirectiveProvidedBy.Marpit,
       type: DirectiveType.Local,
-    },
+      details: 'https://marpit.marp.app/directives?id=backgrounds',
+    }),
 
     // Marp Core extension
-    {
+    createDirectiveInfo({
       name: 'size',
-      description: 'Choose the slide size preset provided by theme.',
+      description: dedent(`
+        Choose the slide size preset provided by theme.
+
+        In Marp Core built-in theme, you can choose from \`16:9\` (1280x720) or \`4:3\` (960x720).
+      `),
       allowed: directiveAlwaysAllowed,
       providedBy: DirectiveProvidedBy.MarpCore,
       type: DirectiveType.Global,
-    },
+      details: 'https://github.com/marp-team/marp-core#size-global-directive',
+    }),
 
-    // Marp CLI meta options
-    {
+    // Marp CLI metadata options
+    createDirectiveInfo({
       name: 'title',
       description: 'Define title of the slide deck.',
       allowed: directiveAlwaysAllowed,
       providedBy: DirectiveProvidedBy.MarpCLI,
       type: DirectiveType.Global,
-    },
-    {
+      details: 'https://github.com/marp-team/marp-cli#metadata',
+    }),
+    createDirectiveInfo({
       name: 'description',
       description: 'Define description of the slide deck.',
       allowed: directiveAlwaysAllowed,
       providedBy: DirectiveProvidedBy.MarpCLI,
       type: DirectiveType.Global,
-    },
-    {
+      details: 'https://github.com/marp-team/marp-cli#metadata',
+    }),
+    createDirectiveInfo({
       name: 'url',
-      description: 'Define canonical URL to the slide deck.',
+      description: 'Define canonical URL for the slide deck.',
       allowed: directiveAlwaysAllowed,
       providedBy: DirectiveProvidedBy.MarpCLI,
       type: DirectiveType.Global,
-    },
-    {
+      details: 'https://github.com/marp-team/marp-cli#metadata',
+    }),
+    createDirectiveInfo({
       name: 'image',
       description: 'Define Open Graph image URL.',
       allowed: directiveAlwaysAllowed,
       providedBy: DirectiveProvidedBy.MarpCLI,
       type: DirectiveType.Global,
-    },
+      details: 'https://github.com/marp-team/marp-cli#metadata',
+    }),
   ]
 
   directives: DirectiveInfo[] = [...DirectiveParser.builtinDirectives]
@@ -252,11 +337,11 @@ export class DirectiveParser extends (EventEmitter as new () => TypedEmitter<Dir
               return false
             })
 
-            this.emit('directive', {
-              info: directiveInfo ? { ...directiveInfo, scoped } : undefined,
-              item,
-              offset,
-            })
+            const info = directiveInfo
+              ? createDirectiveInfo({ ...directiveInfo, scoped })
+              : undefined
+
+            this.emit('directive', { info, item, offset })
           }
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import * as openExtensionSettings from './commands/open-extension-settings'
 import * as showQuickPick from './commands/show-quick-pick'
 import * as toggleMarpPreview from './commands/toggle-marp-preview'
 import diagnostics from './diagnostics/'
+import languageProvider from './language'
 import { marpCoreOptionForPreview, clearMarpCoreOptionCache } from './option'
 import customTheme from './plugins/custom-theme'
 import lineNumber from './plugins/line-number'
@@ -124,6 +125,7 @@ export function extendMarkdownIt(md: any) {
 
 export const activate = ({ subscriptions }: ExtensionContext) => {
   diagnostics(subscriptions)
+  languageProvider(subscriptions)
 
   subscriptions.push(
     commands.registerCommand(exportCommand.command, exportCommand.default),

--- a/src/language.ts
+++ b/src/language.ts
@@ -1,0 +1,59 @@
+import { languages, Disposable, Range, TextDocument, Hover } from 'vscode'
+import { DirectiveParser, DirectiveInfo } from './directive-parser'
+import { detectMarpDocument } from './utils'
+
+interface CollectedDirective {
+  info: DirectiveInfo
+  keyRange: Range
+  range: Range
+}
+
+export function register(subscriptions: Disposable[]) {
+  const collectDirectives = (doc: TextDocument) => {
+    if (detectMarpDocument(doc)) {
+      const parser = new DirectiveParser()
+      const collected: CollectedDirective[] = []
+
+      parser.on('directive', ({ item, info, offset }) => {
+        if (info) {
+          const [start, end] = item.key.range
+          const [, vEnd] = item.value.range
+
+          collected.push({
+            info,
+            keyRange: new Range(
+              doc.positionAt(start + offset),
+              doc.positionAt(end + offset)
+            ),
+            range: new Range(
+              doc.positionAt(start + offset),
+              doc.positionAt(vEnd + offset)
+            ),
+          })
+        }
+      })
+      parser.parse(doc)
+
+      return collected
+    }
+    return []
+  }
+
+  subscriptions.push(
+    languages.registerHoverProvider('markdown', {
+      provideHover: async (doc, pos) => {
+        for (const collected of collectDirectives(doc)) {
+          if (collected.range.contains(pos)) {
+            return new Hover(
+              collected.info.markdownDescription,
+              collected.range
+            )
+          }
+        }
+        return null
+      },
+    })
+  )
+}
+
+export default register

--- a/src/language.ts
+++ b/src/language.ts
@@ -73,8 +73,6 @@ export function register(subscriptions: Disposable[]) {
 
               directivesByTextDocument.set(doc, collected)
 
-              console.log(directivesByTextDocument)
-
               if (activeEditor?.document === doc) {
                 activeEditor.setDecorations(
                   marpDirectiveDecoration,

--- a/src/language.ts
+++ b/src/language.ts
@@ -1,4 +1,14 @@
-import { languages, Disposable, Range, TextDocument, Hover } from 'vscode'
+import lodashDebounce from 'lodash.debounce'
+import {
+  Disposable,
+  Range,
+  TextDocument,
+  ThemeColor,
+  Hover,
+  languages,
+  window,
+  workspace,
+} from 'vscode'
 import { DirectiveParser, DirectiveInfo } from './directive-parser'
 import { detectMarpDocument } from './utils'
 
@@ -9,40 +19,90 @@ interface CollectedDirective {
 }
 
 export function register(subscriptions: Disposable[]) {
-  const collectDirectives = (doc: TextDocument) => {
-    if (detectMarpDocument(doc)) {
-      const parser = new DirectiveParser()
-      const collected: CollectedDirective[] = []
+  let activeEditor = window.activeTextEditor
 
-      parser.on('directive', ({ item, info, offset }) => {
-        if (info) {
-          const [start, end] = item.key.range
-          const [, vEnd] = item.value.range
+  const marpDirectiveDecoration = window.createTextEditorDecorationType({
+    fontWeight: 'bold',
+    color: new ThemeColor('marp.directiveKeyForeground'),
+  })
 
-          collected.push({
-            info,
-            keyRange: new Range(
-              doc.positionAt(start + offset),
-              doc.positionAt(end + offset)
-            ),
-            range: new Range(
-              doc.positionAt(start + offset),
-              doc.positionAt(vEnd + offset)
-            ),
-          })
-        }
-      })
-      parser.parse(doc)
+  const directivesByTextDocument = new Map<TextDocument, CollectedDirective[]>()
+  const parseFuncByTextDocument = new Map<TextDocument, () => void>()
 
-      return collected
+  const remove = (doc: TextDocument) => {
+    directivesByTextDocument.delete(doc)
+
+    if (activeEditor?.document === doc) {
+      activeEditor.setDecorations(marpDirectiveDecoration, [])
     }
-    return []
   }
 
+  const update = (doc: TextDocument) => {
+    if (detectMarpDocument(doc)) {
+      const parse =
+        parseFuncByTextDocument.get(doc) ??
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        parseFuncByTextDocument
+          .set(
+            doc,
+            lodashDebounce(() => {
+              if (!detectMarpDocument(doc)) return
+
+              const parser = new DirectiveParser()
+              const collected: CollectedDirective[] = []
+
+              parser.on('directive', ({ item, info, offset }) => {
+                if (info) {
+                  const [start, end] = item.key.range
+                  const [, vEnd] = item.value.range
+
+                  collected.push({
+                    info,
+                    keyRange: new Range(
+                      doc.positionAt(start + offset),
+                      doc.positionAt(end + offset)
+                    ),
+                    range: new Range(
+                      doc.positionAt(start + offset),
+                      doc.positionAt(vEnd + offset)
+                    ),
+                  })
+                }
+              })
+              parser.parse(doc)
+
+              directivesByTextDocument.set(doc, collected)
+
+              console.log(directivesByTextDocument)
+
+              if (activeEditor?.document === doc) {
+                activeEditor.setDecorations(
+                  marpDirectiveDecoration,
+                  collected.map(({ keyRange }) => keyRange)
+                )
+              }
+            }, 200)
+          )
+          .get(doc)!
+
+      parse()
+    } else {
+      remove(doc)
+    }
+  }
+
+  if (activeEditor) update(activeEditor.document)
+
   subscriptions.push(
+    window.onDidChangeActiveTextEditor((e) => {
+      activeEditor = e
+      if (activeEditor) update(activeEditor.document)
+    }),
+    workspace.onDidChangeTextDocument((e) => update(e.document)),
+    workspace.onDidCloseTextDocument((d) => remove(d)),
     languages.registerHoverProvider('markdown', {
       provideHover: async (doc, pos) => {
-        for (const collected of collectDirectives(doc)) {
+        for (const collected of directivesByTextDocument.get(doc) ?? []) {
           if (collected.range.contains(pos)) {
             return new Hover(
               collected.info.markdownDescription,
@@ -52,7 +112,14 @@ export function register(subscriptions: Disposable[]) {
         }
         return null
       },
-    })
+    }),
+    marpDirectiveDecoration,
+    {
+      dispose() {
+        directivesByTextDocument.clear()
+        parseFuncByTextDocument.clear()
+      },
+    }
   )
 }
 


### PR DESCRIPTION
This is a part of #158.

Add hover provider for recognizable Marp directives by the extension. By hovering a cursor onto the directive, user can peek an instant help about the directive.

![](https://user-images.githubusercontent.com/3993388/118117466-a1b9d700-b426-11eb-8cef-f227a2320796.png)

In the case of `theme` directive, user can preview Marp Core's built-in theme by the image.

![](https://user-images.githubusercontent.com/3993388/118117550-bb5b1e80-b426-11eb-96b4-c8231314809a.png)

### Supported directives

- Marp for VS Code
  - `marp` global directive (Only in the front-matter)
- Marpit
  - Global directives
    - `theme`
    - `style`
    - `headingDivider`
  - Local directives
    - `paginate`
    - `header`
    - `footer`
    - `class`
    - `backgroundColor`
    - `backgroundImage`
    - `backgroundPosition`
    - `backgroundRepeat`
    - `backgroundSize`
    - `color`
- Marp Core
  - `size` global directive
- Marp CLI
  - `title` global directive
  - `description` global directive
  - `url` global directive
  - `image` global directive
