### PR TITLE
Fix wrong highlight in CRLF

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,20 +83,6 @@ jobs:
     steps:
       - audit
 
-  unit-electron9:
-    executor:
-      name: node
-      version: '12.14.1'
-    steps:
-      - test
-
-  unit-electron11:
-    executor:
-      name: node
-      version: '12.18.3'
-    steps:
-      - test
-
   unit-electron12:
     executor:
       name: node
@@ -108,12 +94,6 @@ workflows:
   test:
     jobs:
       - audit
-      - unit-electron9:
-          requires:
-            - audit
-      - unit-electron11:
-          requires:
-            - audit
       - unit-electron12:
           requires:
             - audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Wrong highlight in CRLF ([#239](https://github.com/marp-team/marp-vscode/issues/239), [#240](https://github.com/marp-team/marp-vscode/pull/240))
+
 ## v1.0.0 - 2021-05-17
 
 ### Breaking

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "unist-util-visit": "^3.1.0",
         "utf-8-validate": "^5.0.5",
         "vsce": "^1.88.0",
-        "yaml": "^1.10.2"
+        "yaml": "^2.0.0-5"
       },
       "engines": {
         "vscode": "^1.56.0"
@@ -4532,6 +4532,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/cross-spawn": {
@@ -15924,11 +15932,12 @@
       "dev": true
     },
     "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "version": "2.0.0-5",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-5.tgz",
+      "integrity": "sha512-qH5L5eqW8cyv/N1U6rkK/O0M7kOK3BSo48d05Ptm03ITNsVFwg6TQ47wR72Db/ULWH5RfNJv+CqnG17Pyn8eqQ==",
+      "dev": true,
       "engines": {
-        "node": ">= 6"
+        "node": ">= 10"
       }
     },
     "node_modules/yargs": {
@@ -19518,6 +19527,13 @@
         "parse-json": "^5.0.0",
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
+      },
+      "dependencies": {
+        "yaml": {
+          "version": "1.10.2",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+          "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+        }
       }
     },
     "cross-spawn": {
@@ -28303,9 +28319,10 @@
       "dev": true
     },
     "yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+      "version": "2.0.0-5",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-5.tgz",
+      "integrity": "sha512-qH5L5eqW8cyv/N1U6rkK/O0M7kOK3BSo48d05Ptm03ITNsVFwg6TQ47wR72Db/ULWH5RfNJv+CqnG17Pyn8eqQ==",
+      "dev": true
     },
     "yargs": {
       "version": "17.0.1",

--- a/package.json
+++ b/package.json
@@ -273,7 +273,7 @@
     "unist-util-visit": "^3.1.0",
     "utf-8-validate": "^5.0.5",
     "vsce": "^1.88.0",
-    "yaml": "^1.10.2"
+    "yaml": "^2.0.0-5"
   },
   "dependencies": {
     "@marp-team/marp-cli": "^1.1.1",

--- a/src/diagnostics/deprecated-dollar-prefix.ts
+++ b/src/diagnostics/deprecated-dollar-prefix.ts
@@ -30,7 +30,7 @@ export function register(
   diagnostics: Diagnostic[]
 ) {
   directiveParser.on('directive', ({ item, offset }) => {
-    if (warnDirectives.includes(item.key.value)) {
+    if (warnDirectives.includes(item.key.value) && item.key.range) {
       const name = item.key.value.slice(1)
       const [start, end] = item.key.range
 

--- a/src/diagnostics/overloading-global-directive.ts
+++ b/src/diagnostics/overloading-global-directive.ts
@@ -1,6 +1,6 @@
 import { Diagnostic, DiagnosticSeverity, Range, TextDocument } from 'vscode'
-import { Pair } from 'yaml/types'
 import { DirectiveParser, DirectiveType } from '../directives/parser'
+import type { Pair } from 'yaml'
 
 interface ParsedGlobalDirective {
   item: Pair
@@ -21,7 +21,7 @@ export function register(
   })
 
   directiveParser.on('directive', ({ item, offset, info }) => {
-    if (info?.type === DirectiveType.Global) {
+    if (info?.type === DirectiveType.Global && item.key.range) {
       const [start] = item.key.range
       const [, end] = item.value?.range ?? item.key.range
 

--- a/src/diagnostics/unknown-theme.ts
+++ b/src/diagnostics/unknown-theme.ts
@@ -21,7 +21,7 @@ export function register(
   })
 
   directiveParser.on('directive', ({ item, offset, info }) => {
-    if (info?.name === 'theme' && item.value) {
+    if (info?.name === 'theme' && item.value?.range) {
       const [start, end] = item.value.range
 
       parsed = {

--- a/src/language/parser.ts
+++ b/src/language/parser.ts
@@ -113,7 +113,7 @@ export class LanguageParser
       })
       .on('comment', ({ range }) => commentRanges.push(range))
       .on('directive', ({ item, info, offset }) => {
-        if (info) {
+        if (info && item.key.range) {
           const [start, end] = item.key.range
           const [, vEnd] = item.value?.range ?? item.key.range
 


### PR DESCRIPTION
Fix #239.

- The current YAML parser ([yaml](https://github.com/eemeli/yaml)) removes CR in the normalize process. So we will use `yaml@next` (& normalize trailing CR of the passed text to prevent parse error)
- HTML comment parser ([rehype](https://github.com/rehypejs/rehype)) returns the comment node with normalized value. To pass the raw text including CR into YAML parser, we have to pick substring from HTML sourcemap manually.