### PR TITLE
Update vsce

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,9 +1,8 @@
-*
-*/**
-!node_modules/**
+/*
+!/node_modules
 !.vscodeignore
-!images/**
-!lib/*
+!/images
+!/lib
 !CHANGELOG.md
 !LICENSE
 !README.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "unified": "^9.2.1",
         "unist-util-visit": "^3.1.0",
         "utf-8-validate": "^5.0.5",
-        "vsce": "^1.92.0",
+        "vsce": "^1.93.0",
         "yaml": "^2.0.0-5"
       },
       "engines": {
@@ -4407,9 +4407,9 @@
       }
     },
     "node_modules/cheerio-select/node_modules/domutils": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
-      "integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+      "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
       "dev": true,
       "dependencies": {
         "dom-serializer": "^1.0.1",
@@ -4462,9 +4462,9 @@
       }
     },
     "node_modules/cheerio/node_modules/domutils": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
-      "integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+      "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
       "dev": true,
       "dependencies": {
         "dom-serializer": "^1.0.1",
@@ -4855,9 +4855,9 @@
       }
     },
     "node_modules/css-select/node_modules/domutils": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
-      "integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+      "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
       "dev": true,
       "dependencies": {
         "dom-serializer": "^1.0.1",
@@ -5820,9 +5820,9 @@
       }
     },
     "node_modules/eslint/node_modules/globals": {
-      "version": "13.8.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.8.0.tgz",
-      "integrity": "sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==",
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz",
+      "integrity": "sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -12528,13 +12528,13 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.2.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.15.tgz",
-      "integrity": "sha512-2zO3b26eJD/8rb106Qu2o7Qgg52ND5HPjcyQiK2B98O388h43A448LCslC0dI2P97wCAQRJsFvwTRcXxTKds+Q==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.0.tgz",
+      "integrity": "sha512-+ogXpdAjWGa+fdYY5BQ96V/6tAo+TdSSIMP5huJBIygdWwKtVoB5JWZ7yUd4xZ8r+8Kvvx4nyg/PQ071H4UtcQ==",
       "dependencies": {
         "colorette": "^1.2.2",
         "nanoid": "^3.1.23",
-        "source-map": "^0.6.1"
+        "source-map-js": "^0.6.2"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -12844,14 +12844,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
-    },
-    "node_modules/postcss/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/pptxgenjs": {
       "version": "3.6.0",
@@ -13865,6 +13857,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
@@ -14579,9 +14579,9 @@
       }
     },
     "node_modules/table/node_modules/ajv": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.4.0.tgz",
-      "integrity": "sha512-7QD2l6+KBSLwf+7MuYocbWvRPdOu63/trReTLu2KFwkgctnub1auoF+Y1WYcm09CTM7quuscrzqmASaLHC/K4Q==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
+      "integrity": "sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -15425,10 +15425,11 @@
       }
     },
     "node_modules/vsce": {
-      "version": "1.92.0",
-      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.92.0.tgz",
-      "integrity": "sha512-gL6FBn2cOf4kotUV7VeiXWoY7eaZAz6NTvqG66a1rK/VDE8ChrHaS21zs9G9t1spzoBi7vxfE0ZKYqyusQGQ7g==",
+      "version": "1.93.0",
+      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.93.0.tgz",
+      "integrity": "sha512-RgmxwybXenP6tTF0PLh97b/RRLp1RkzjAHNya3QAfv1EZVg+lfoBiAaXogpmOGjYr8OskkqP5tIa3D/Q6X9lrw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "azure-devops-node-api": "^10.2.2",
         "chalk": "^2.4.2",
@@ -15445,7 +15446,7 @@
         "parse-semver": "^1.1.1",
         "read": "^1.0.7",
         "semver": "^5.1.0",
-        "tmp": "0.0.29",
+        "tmp": "^0.2.1",
         "typed-rest-client": "^1.8.4",
         "url-join": "^1.1.0",
         "yauzl": "^2.3.1",
@@ -15514,18 +15515,6 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver"
-      }
-    },
-    "node_modules/vsce/node_modules/tmp": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
-      "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
-      "dev": true,
-      "dependencies": {
-        "os-tmpdir": "~1.0.1"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/w3c-hr-time": {
@@ -19265,9 +19254,9 @@
           }
         },
         "domutils": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
-          "integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+          "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
           "dev": true,
           "requires": {
             "dom-serializer": "^1.0.1",
@@ -19329,9 +19318,9 @@
           }
         },
         "domutils": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
-          "integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+          "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
           "dev": true,
           "requires": {
             "dom-serializer": "^1.0.1",
@@ -19634,9 +19623,9 @@
           }
         },
         "domutils": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
-          "integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+          "integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
           "dev": true,
           "requires": {
             "dom-serializer": "^1.0.1",
@@ -20170,9 +20159,9 @@
           "dev": true
         },
         "globals": {
-          "version": "13.8.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.8.0.tgz",
-          "integrity": "sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==",
+          "version": "13.9.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.9.0.tgz",
+          "integrity": "sha512-74/FduwI/JaIrr1H8e71UbDE+5x7pIPs1C2rrwC52SszOo043CsWOZEMW7o2Y58xwm9b+0RBKDxY5n2sUpEFxA==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -25455,20 +25444,13 @@
       }
     },
     "postcss": {
-      "version": "8.2.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.15.tgz",
-      "integrity": "sha512-2zO3b26eJD/8rb106Qu2o7Qgg52ND5HPjcyQiK2B98O388h43A448LCslC0dI2P97wCAQRJsFvwTRcXxTKds+Q==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.0.tgz",
+      "integrity": "sha512-+ogXpdAjWGa+fdYY5BQ96V/6tAo+TdSSIMP5huJBIygdWwKtVoB5JWZ7yUd4xZ8r+8Kvvx4nyg/PQ071H4UtcQ==",
       "requires": {
         "colorette": "^1.2.2",
         "nanoid": "^3.1.23",
-        "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
+        "source-map-js": "^0.6.2"
       }
     },
     "postcss-html": {
@@ -26482,6 +26464,11 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
       "dev": true
     },
+    "source-map-js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug=="
+    },
     "source-map-support": {
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
@@ -27050,9 +27037,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.4.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.4.0.tgz",
-          "integrity": "sha512-7QD2l6+KBSLwf+7MuYocbWvRPdOu63/trReTLu2KFwkgctnub1auoF+Y1WYcm09CTM7quuscrzqmASaLHC/K4Q==",
+          "version": "8.6.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.0.tgz",
+          "integrity": "sha512-cnUG4NSBiM4YFBxgZIj/In3/6KX+rQ2l2YPRVcvAMQGWEPKuXoPIhxzwqh31jA3IPbI4qEOp/5ILI4ynioXsGQ==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -27712,9 +27699,9 @@
       }
     },
     "vsce": {
-      "version": "1.92.0",
-      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.92.0.tgz",
-      "integrity": "sha512-gL6FBn2cOf4kotUV7VeiXWoY7eaZAz6NTvqG66a1rK/VDE8ChrHaS21zs9G9t1spzoBi7vxfE0ZKYqyusQGQ7g==",
+      "version": "1.93.0",
+      "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.93.0.tgz",
+      "integrity": "sha512-RgmxwybXenP6tTF0PLh97b/RRLp1RkzjAHNya3QAfv1EZVg+lfoBiAaXogpmOGjYr8OskkqP5tIa3D/Q6X9lrw==",
       "dev": true,
       "requires": {
         "azure-devops-node-api": "^10.2.2",
@@ -27732,7 +27719,7 @@
         "parse-semver": "^1.1.1",
         "read": "^1.0.7",
         "semver": "^5.1.0",
-        "tmp": "0.0.29",
+        "tmp": "^0.2.1",
         "typed-rest-client": "^1.8.4",
         "url-join": "^1.1.0",
         "yauzl": "^2.3.1",
@@ -27787,15 +27774,6 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
-        },
-        "tmp": {
-          "version": "0.0.29",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
-          "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "~1.0.1"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
     "unified": "^9.2.1",
     "unist-util-visit": "^3.1.0",
     "utf-8-validate": "^5.0.5",
-    "vsce": "^1.92.0",
+    "vsce": "^1.93.0",
     "yaml": "^2.0.0-5"
   },
   "dependencies": {


### PR DESCRIPTION
It's a lost part of #245. Re-bumped vsce to 1.93.0.

### Notable changes

- vsce is now following `.gitignore` rules strictly so existing allowlist in `.vscodeignore` has broken. I've updated `.vscodeignore` to make parsable by `ignore` npm module with keeping the same allow setting. (https://github.com/microsoft/vscode-vsce/issues/576)