### PR TITLE
Implement fallback of scroll stabilizer to reduce scroll jumping while editing

### DIFF
--- a/src/preview.ts
+++ b/src/preview.ts
@@ -1,9 +1,24 @@
 import { observer } from '@marp-team/marp-core/browser'
+import lodashDebounce from 'lodash.debounce'
+
+const stabilizerThrottleDelay = 150
+
+const onDOMContentLoaded = (callback: () => void) => {
+  const { readyState } = document
+
+  if (readyState === 'complete' || readyState === 'interactive') {
+    setTimeout(callback, 0)
+  } else {
+    window.addEventListener('DOMContentLoaded', callback)
+  }
+}
 
 export default function preview() {
   const marpVscode = document.getElementById('marp-vscode')
 
   if (marpVscode) {
+    const { documentId } = marpVscode.dataset
+
     document.body.classList.add('marp-vscode')
 
     // Remove default styles
@@ -18,5 +33,59 @@ export default function preview() {
 
     // Run Marp observer
     observer()
+
+    if (documentId) {
+      // Scroll stabilizer
+      //
+      // WARN: It works as a fallback logic for VS Code built-in preview
+      // stabilizer and not always apply the updated scroll position.
+      // Specifically this logic will apply only when executed Marp's preview
+      // script after VS Code's built-in preview script. VS Code uses
+      // `<script async>` to inject external preview scripts so all preview
+      // scripts execute with an unpredictable order.
+
+      const count = marpVscode.querySelectorAll(
+        ':scope > svg[data-marpit-svg]'
+      ).length
+
+      const trySettingToStorage = (key: string, value: string) => {
+        try {
+          sessionStorage.setItem(`marp-vscode-${documentId}-${key}`, value)
+        } catch (_) {
+          // no ops
+        }
+      }
+
+      const tryGettingFromStorage = (key: string) => {
+        try {
+          return sessionStorage.getItem(`marp-vscode-${documentId}-${key}`)
+        } catch (_) {
+          return null
+        }
+      }
+
+      const setScrollY = lodashDebounce(
+        () => trySettingToStorage('scrollY', window.scrollY.toString()),
+        stabilizerThrottleDelay,
+        { leading: true, maxWait: stabilizerThrottleDelay, trailing: true }
+      )
+
+      const storedScrollY = tryGettingFromStorage('scrollY')
+
+      if (storedScrollY) {
+        const storedCount = tryGettingFromStorage('count')
+
+        // Apply when the number of pages did not change from before editing
+        if (storedCount && Number.parseInt(storedCount) === count) {
+          window.scrollTo({ top: Number.parseFloat(storedScrollY) })
+        }
+      }
+
+      // Set current position and the number of pages
+      trySettingToStorage('count', count.toString())
+
+      onDOMContentLoaded(setScrollY)
+      window.addEventListener('scroll', setScrollY)
+    }
   }
 }

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -7,7 +7,7 @@ const onDOMContentLoaded = (callback: () => void) => {
   const { readyState } = document
 
   if (readyState === 'complete' || readyState === 'interactive') {
-    setTimeout(callback, 0)
+    callback()
   } else {
     window.addEventListener('DOMContentLoaded', callback)
   }
@@ -84,7 +84,7 @@ export default function preview() {
       // Set current position and the number of pages
       trySettingToStorage('count', count.toString())
 
-      onDOMContentLoaded(setScrollY)
+      onDOMContentLoaded(() => setTimeout(setScrollY, 16))
       window.addEventListener('scroll', setScrollY)
     }
   }


### PR DESCRIPTION
For keeping [extension sustainabillity](https://marp.app/blog/the-story-of-marp-next), Marp for VS Code has not any scroll-sync logic and relies to [VS Code's built-in preview script](https://github.com/microsoft/vscode/tree/main/extensions/markdown-language-features/preview-src). Scroll sync is working correctly in almost cases, but sometimes the preview pane brings unexpected scroll when updated webview by editing.

When updating preview, VS Code is trying to restore the previous scroll position by calling `scrollTo` on loading. A timing of execution this script is same as other extensions contributed scripts included Marp. However, they will run in unpredictable order because they are injected through `<script async>`. If VS Code ran built-in initialization script before Marp's preview script, a calculated scroll position for stabilization would be wrong due to its styles are based on what have not applied Marp specific styles. On the other hand, the built-in scroll stabilization will work to Marp slides perfectly if ran Marp preview script before built-in script. This is reason why user _occasionally_ see to unexpected scroll.

This PR implemented a fallback logic of scroll stabilizer to reduce scroll jumping while editing. **It does not always apply the updated scroll position.** If built-in preview script has not run on running Marp script, the scroll position will override with the built-in logic. And the fallback will be disabled temporally if changed the number of pages.

It would not resolve #248 completely, but can reduce furastrating jumps while editing text. It might be related to #173 too.