### PR TITLE
Add `markdown.marp.newMarpMarkdown` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- `markdown.marp.newMarpMarkdown` command to create empty Marp Markdown ([#255](https://github.com/marp-team/marp-vscode/pull/255))
+- Contribution to "New File…" in File menu and welcome screen _(Experimental: Required opt-in by `workbench.welcome.experimental.startEntries` in VS Code 1.58+)_ (#255) ([#255](https://github.com/marp-team/marp-vscode/pull/255))
+
 ## v1.0.3 - 2021-06-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -190,7 +190,15 @@
           "when": "config.markdown.marp.toolbarButtonForQuickPick && editorLangId == markdown"
         }
       ]
-    }
+    },
+    "startEntries": [
+      {
+        "title": "Marp Markdown",
+        "description": "For creating slide deck",
+        "catagory": "file",
+        "command": "markdown.marp.newMarpMarkdown"
+      }
+    ]
   },
   "private": true,
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
       {
         "title": "Marp Markdown",
         "description": "For creating slide deck",
-        "catagory": "file",
+        "category": "file",
         "command": "markdown.marp.newMarpMarkdown"
       }
     ]

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "activationEvents": [
     "onLanguage:markdown",
     "onCommand:markdown.marp.export",
+    "onCommand:markdown.marp.newMarpMarkdown",
     "onCommand:markdown.marp.showQuickPick",
     "onCommand:markdown.marp.toggleMarpFeature"
   ],
@@ -71,12 +72,17 @@
       {
         "category": "Marp",
         "command": "markdown.marp.export",
-        "title": "Export slide deck..."
+        "title": "Export Slide Deck..."
+      },
+      {
+        "category": "Marp",
+        "command": "markdown.marp.newMarpMarkdown",
+        "title": "New Untitled Marp Markdown For Slide Deck"
       },
       {
         "category": "Marp",
         "command": "markdown.marp.showQuickPick",
-        "title": "Show quick pick of Marp commands...",
+        "title": "Show Quick Pick Of Marp Commands...",
         "icon": {
           "dark": "./images/icon-dark.svg",
           "light": "./images/icon-light.svg"
@@ -85,7 +91,7 @@
       {
         "category": "Marp",
         "command": "markdown.marp.toggleMarpFeature",
-        "title": "Toggle Marp feature for current Markdown"
+        "title": "Toggle Marp Feature For Current Markdown"
       }
     ],
     "configuration": {

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -100,6 +100,8 @@ export class Range {
   }
 }
 
+export class Selection extends Range {}
+
 export const RelativePattern = jest.fn()
 
 export const ThemeColor = jest.fn(() => '#000000ff')
@@ -171,6 +173,7 @@ export const window = {
   showErrorMessage: jest.fn(),
   showQuickPick: jest.fn(),
   showSaveDialog: jest.fn(),
+  showTextDocument: jest.fn(async () => ({})),
   showWarningMessage: jest.fn(),
   withProgress: jest.fn(),
 }
@@ -195,6 +198,7 @@ export const workspace = {
   onDidChangeTextDocument: jest.fn(),
   onDidCloseTextDocument: jest.fn(),
   onDidGrantWorkspaceTrust: jest.fn(),
+  openTextDocument: jest.fn(),
   textDocuments: [] as any,
 
   _setConfiguration: (conf: MockedConf = {}) => {

--- a/src/commands/new-marp-markdown.test.ts
+++ b/src/commands/new-marp-markdown.test.ts
@@ -1,0 +1,29 @@
+import { window, workspace, Selection } from 'vscode'
+import newMarpMarkdown from './new-marp-markdown'
+
+jest.mock('vscode')
+
+describe('newMarpMarkdown command', () => {
+  it('opens new Markdown document with preset of frontmatter', async () => {
+    const positionAt = jest.fn((pos: number) => pos as any)
+    const openTextDocument = jest
+      .spyOn(workspace, 'openTextDocument')
+      .mockResolvedValue({ positionAt } as any)
+
+    await newMarpMarkdown()
+
+    expect(openTextDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringMatching(/^---\nmarp: true\n---/),
+        language: 'markdown',
+      })
+    )
+
+    const document = await openTextDocument.mock.results[0].value
+    expect(window.showTextDocument).toHaveBeenCalledWith(document)
+
+    const textEditor = await (window.showTextDocument as any).mock.results[0]
+      .value
+    expect(textEditor.selection).toStrictEqual(expect.any(Selection))
+  })
+})

--- a/src/commands/new-marp-markdown.ts
+++ b/src/commands/new-marp-markdown.ts
@@ -1,0 +1,17 @@
+import { Selection, window, workspace } from 'vscode'
+
+export const command = 'markdown.marp.newMarpMarkdown'
+
+export default async function newMarpMarkdown() {
+  const newDocument = await workspace.openTextDocument({
+    content: '---\nmarp: true\n---\n\n',
+    language: 'markdown',
+  })
+
+  const editor = await window.showTextDocument(newDocument)
+
+  editor.selection = new Selection(
+    newDocument.positionAt(20),
+    newDocument.positionAt(20)
+  )
+}

--- a/src/commands/show-quick-pick.ts
+++ b/src/commands/show-quick-pick.ts
@@ -22,7 +22,7 @@ for (const cmdPath of contributedCommands) {
 }
 
 availableCommands.push({
-  label: '$(settings-gear) Open extension settings',
+  label: '$(settings-gear) Open Extension Settings',
   [cmdSymbol]: openExtensionSettingsCommand,
 })
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import { Marp } from '@marp-team/marp-core'
 import { ExtensionContext, Uri, commands, workspace } from 'vscode'
 import * as exportCommand from './commands/export'
+import * as newMarpMarkdown from './commands/new-marp-markdown'
 import * as openExtensionSettings from './commands/open-extension-settings'
 import * as showQuickPick from './commands/show-quick-pick'
 import * as toggleMarpFeature from './commands/toggle-marp-feature'
@@ -178,6 +179,7 @@ export const activate = ({ subscriptions }: ExtensionContext) => {
 
   subscriptions.push(
     commands.registerCommand(exportCommand.command, exportCommand.default),
+    commands.registerCommand(newMarpMarkdown.command, newMarpMarkdown.default),
     commands.registerCommand(
       openExtensionSettings.command,
       openExtensionSettings.default


### PR DESCRIPTION
Added `markdown.marp.newMarpMarkdown` command to create untitled Marp Markdown file. It will create Markdown file with predegining `marp: true` so user can start to write presentation straight away.

It will be used by a planning new sidebar: https://marp.app/blog/marp-for-vs-code-v1#whats-next

![plan-sidebar](https://user-images.githubusercontent.com/3993388/122845765-578a1680-d33f-11eb-927f-976fa1f41eb8.png)