### PR TITLE
Allow to disable math typesetting in Marp Markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `markdown.marp.newMarpMarkdown` command to create empty Marp Markdown ([#255](https://github.com/marp-team/marp-vscode/pull/255))
 - Contribution to "New File…" in File menu and welcome screen _(Experimental: Required opt-in by `workbench.welcome.experimental.startEntries` in VS Code 1.58+)_ ([#255](https://github.com/marp-team/marp-vscode/pull/255))
+- Allow to disable math typesetting in Marp Markdown by `"markdown.marp.mathTypesetting": "off"` setting ([#256](https://github.com/marp-team/marp-vscode/issues/256), [#258](https://github.com/marp-team/marp-vscode/pull/258))
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -145,14 +145,16 @@
         "markdown.marp.mathTypesetting": {
           "type": "string",
           "enum": [
+            "off",
             "mathjax",
             "katex"
           ],
           "default": "katex",
-          "markdownDescription": "Controls math typesetting library for rendering math syntax by [Marp Core](https://github.com/marp-team/marp-core).",
+          "markdownDescription": "Controls math typesetting library for rendering math syntax by [Marp Core](https://github.com/marp-team/marp-core). Please note that math rendering in Marp Markdown is not following the setting in `#markdown.math.enabled#`.",
           "markdownEnumDescriptions": [
-            "MathJax (https://www.mathjax.org/)",
-            "KaTeX (https://katex.org/): The default library in Marp Core"
+            "Disable math typesetting.",
+            "Use MathJax (https://www.mathjax.org/).",
+            "Use KaTeX (https://katex.org/). It is the default library in both of Marp and VS Code."
           ]
         },
         "markdown.marp.outlineExtension": {

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -225,8 +225,8 @@ describe('#extendMarkdownIt', () => {
 
         const html = md().render(marpMd('$a=b$'))
         expect(html).toContain('$a=b$')
-        expect(html).not.toContain(/katex/i)
-        expect(html).not.toContain(/mathjax/i)
+        expect(html).not.toMatch(/katex/i)
+        expect(html).not.toMatch(/mathjax/i)
       })
     })
 
@@ -451,7 +451,7 @@ describe('#extendMarkdownIt', () => {
       md.render('test', { resourceProvider })
 
       expect(_contentProvider.getScripts()).toMatchInlineSnapshot(`
-"<script
+"<script 
   src=\\"https://example.com/marp-vscode/preview.js\\"
   nonce=\\"0987654321\\"
 ></script>

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -224,7 +224,7 @@ describe('#extendMarkdownIt', () => {
         setConfiguration({ 'markdown.marp.mathTypesetting': 'off' })
 
         const html = md().render(marpMd('$a=b$'))
-        expect(html).toContain('<p>$a=b$</p>')
+        expect(html).toContain('$a=b$')
         expect(html).not.toContain(/katex/i)
         expect(html).not.toContain(/mathjax/i)
       })
@@ -451,7 +451,7 @@ describe('#extendMarkdownIt', () => {
       md.render('test', { resourceProvider })
 
       expect(_contentProvider.getScripts()).toMatchInlineSnapshot(`
-"<script 
+"<script
   src=\\"https://example.com/marp-vscode/preview.js\\"
   nonce=\\"0987654321\\"
 ></script>

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -219,6 +219,15 @@ describe('#extendMarkdownIt', () => {
         expect(html).not.toContain('katex')
         expect(html).toContain('MathJax')
       })
+
+      it('disables math syntax when setting "off"', () => {
+        setConfiguration({ 'markdown.marp.mathTypesetting': 'off' })
+
+        const html = md().render(marpMd('$a=b$'))
+        expect(html).toContain('<p>$a=b$</p>')
+        expect(html).not.toContain(/katex/i)
+        expect(html).not.toContain(/mathjax/i)
+      })
     })
 
     describe('markdown.marp.themes', () => {

--- a/src/option.ts
+++ b/src/option.ts
@@ -30,6 +30,15 @@ const breaks = (inheritedValue: boolean): boolean => {
 const enableHtml = () =>
   marpConfiguration().get<boolean>('enableHtml') && workspace.isTrusted
 
+const math = () => {
+  const conf = marpConfiguration().get<'off' | 'katex' | 'mathjax'>(
+    'mathTypesetting'
+  )
+
+  if (conf === 'off') return false
+  return conf ?? 'katex'
+}
+
 export const marpCoreOptionForPreview = (
   baseOption: Options & MarpOptions
 ): MarpOptions => {
@@ -41,7 +50,7 @@ export const marpCoreOptionForPreview = (
         breaks: breaks(!!baseOption.breaks),
         typographer: baseOption.typographer,
       },
-      math: marpConfiguration().get<'katex' | 'mathjax'>('mathTypesetting'),
+      math: math(),
       minifyCSS: false,
       script: false,
     }
@@ -63,7 +72,7 @@ export const marpCoreOptionForCLI = async (
         breaks: breaks(!!confMdPreview.get<boolean>('breaks')),
         typographer: confMdPreview.get<boolean>('typographer'),
       },
-      math: marpConfiguration().get<'katex' | 'mathjax'>('mathTypesetting'),
+      math: math(),
     },
     themeSet: [] as string[],
     vscode: {} as Record<string, any>,


### PR DESCRIPTION
Added "off" option to `markdown.marp.mathTypesetting` for disabling math typesetting. It follows a use case of `markdown.math.enabled: false` in VS Code 1.58.

Close #256.