### PR TITLE
Use node-fetch instead of axios to reduce dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - [`math` global directive](https://github.com/marp-team/marp-core#math-global-directive) for switching math typesetting library in current Markdown
 - Upgrade Marp CLI to [v1.2.0](https://github.com/marp-team/marp-cli/releases/tag/v1.2.0) ([#265](https://github.com/marp-team/marp-vscode/pull/265))
 - Upgrade dependent packages to the latest ([#265](https://github.com/marp-team/marp-vscode/pull/265))
+- Use bundled `node-fetch` instead of `axios` to improve install performance ([#268](https://github.com/marp-team/marp-vscode/pull/268))
 
 ## v1.1.0 - 2021-07-08
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,9 +22,11 @@
         "@types/jest": "^26.0.24",
         "@types/lodash.debounce": "^4.0.6",
         "@types/markdown-it": "^12.0.3",
+        "@types/node-fetch": "^2.5.12",
         "@types/vscode": "~1.56.0",
         "@typescript-eslint/eslint-plugin": "^4.28.4",
         "@typescript-eslint/parser": "^4.28.4",
+        "abort-controller": "^3.0.0",
         "bufferutil": "^4.0.3",
         "builtin-modules": "^3.2.0",
         "codecov": "^3.8.3",
@@ -40,6 +42,7 @@
         "lodash.debounce": "^4.0.8",
         "markdown-it": "^12.1.0",
         "nanoid": "^3.1.23",
+        "node-fetch": "^2.6.1",
         "npm-run-all": "^4.1.5",
         "portfinder": "^1.0.28",
         "prettier": "^2.3.2",
@@ -2945,6 +2948,16 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.1.tgz",
       "integrity": "sha512-UW7cbLqf/Wu5XH2RKKY1cHwUNLicIDRLMraYKz+HHAerJ0ZffUEk+fMnd8qU2JaS6cAy0r8tsaf7yqHASf/Y0Q=="
     },
+    "node_modules/@types/node-fetch": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz",
+      "integrity": "sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
@@ -3232,6 +3245,18 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.7",
@@ -5748,6 +5773,15 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/execa": {
@@ -16692,6 +16726,16 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.1.tgz",
       "integrity": "sha512-UW7cbLqf/Wu5XH2RKKY1cHwUNLicIDRLMraYKz+HHAerJ0ZffUEk+fMnd8qU2JaS6cAy0r8tsaf7yqHASf/Y0Q=="
     },
+    "@types/node-fetch": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz",
+      "integrity": "sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
     "@types/normalize-package-data": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
@@ -16897,6 +16941,15 @@
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
+    },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
     },
     "accepts": {
       "version": "1.3.7",
@@ -18793,6 +18846,12 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true
     },
     "execa": {
       "version": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -252,9 +252,11 @@
     "@types/jest": "^26.0.24",
     "@types/lodash.debounce": "^4.0.6",
     "@types/markdown-it": "^12.0.3",
+    "@types/node-fetch": "^2.5.12",
     "@types/vscode": "~1.56.0",
     "@typescript-eslint/eslint-plugin": "^4.28.4",
     "@typescript-eslint/parser": "^4.28.4",
+    "abort-controller": "^3.0.0",
     "bufferutil": "^4.0.3",
     "builtin-modules": "^3.2.0",
     "codecov": "^3.8.3",
@@ -270,6 +272,7 @@
     "lodash.debounce": "^4.0.8",
     "markdown-it": "^12.1.0",
     "nanoid": "^3.1.23",
+    "node-fetch": "^2.6.1",
     "npm-run-all": "^4.1.5",
     "portfinder": "^1.0.28",
     "prettier": "^2.3.2",
@@ -293,7 +296,6 @@
   },
   "dependencies": {
     "@marp-team/marp-cli": "^1.2.0",
-    "@marp-team/marp-core": "^2.1.0",
-    "axios": "^0.21.1"
+    "@marp-team/marp-core": "^2.1.0"
   }
 }

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -3,13 +3,13 @@ import fs from 'fs'
 import path from 'path'
 import { TextEncoder } from 'util'
 import { Marp } from '@marp-team/marp-core'
-import axios from 'axios'
 import dedent from 'dedent'
 import markdownIt from 'markdown-it'
+import * as nodeFetch from 'node-fetch'
 import { Uri, commands, workspace } from 'vscode'
 
 jest.mock('fs')
-jest.mock('axios')
+jest.mock('node-fetch')
 jest.mock('vscode')
 
 let themes: typeof import('./themes')['default']
@@ -241,16 +241,16 @@ describe('#extendMarkdownIt', () => {
       })
 
       it('registers pre-loaded themes from URL defined in configuration', async () => {
-        const axiosGet = jest
-          .spyOn(axios, 'get')
-          .mockResolvedValue({ data: css })
+        const fetch = jest
+          .spyOn(nodeFetch, 'default')
+          .mockResolvedValue({ ok: true, text: async () => css } as any)
 
         setConfiguration({ 'markdown.marp.themes': [themeURL] })
 
         const markdown = md()
         await Promise.all(themes.loadStyles(Uri.parse('.')))
 
-        expect(axiosGet).toHaveBeenCalledWith(themeURL, expect.any(Object))
+        expect(fetch).toHaveBeenCalledWith(themeURL, expect.any(Object))
         expect(markdown.render(marpMd('<!--theme: example-->'))).toContain(css)
       })
 
@@ -298,9 +298,10 @@ describe('#extendMarkdownIt', () => {
       })
 
       it('cannot override built-in themes by custom theme', async () => {
-        jest
-          .spyOn(axios, 'get')
-          .mockResolvedValue({ data: '/*\n@theme default\n@custom theme\n*/' })
+        jest.spyOn(nodeFetch, 'default').mockResolvedValue({
+          ok: true,
+          text: async () => '/*\n@theme default\n@custom theme\n*/',
+        } as any)
 
         setConfiguration({ 'markdown.marp.themes': [themeURL] })
 
@@ -451,15 +452,15 @@ describe('#extendMarkdownIt', () => {
       md.render('test', { resourceProvider })
 
       expect(_contentProvider.getScripts()).toMatchInlineSnapshot(`
-"<script 
-  src=\\"https://example.com/marp-vscode/preview.js\\"
-  nonce=\\"0987654321\\"
-></script>
-<script async
-  src=\\"https://example.com/vscode-builtin/script.js\\"
-  nonce=\\"1234567890\\"
-></script>"
-`)
+        "<script 
+          src=\\"https://example.com/marp-vscode/preview.js\\"
+          nonce=\\"0987654321\\"
+        ></script>
+        <script async
+          src=\\"https://example.com/vscode-builtin/script.js\\"
+          nonce=\\"1234567890\\"
+        ></script>"
+      `)
     })
 
     it('emits warning if happened some trouble while patching', () => {

--- a/src/option.test.ts
+++ b/src/option.test.ts
@@ -1,10 +1,10 @@
 import fs from 'fs'
 import { promisify } from 'util'
-import axios from 'axios'
+import * as nodeFetch from 'node-fetch'
 import { Uri, workspace } from 'vscode'
 import * as option from './option'
 
-jest.mock('axios')
+jest.mock('node-fetch')
 jest.mock('vscode')
 
 const readFile = promisify(fs.readFile)
@@ -93,7 +93,9 @@ describe('Option', () => {
 
         // Theme CSS
         jest.spyOn(console, 'log').mockImplementation()
-        jest.spyOn(axios, 'get').mockResolvedValue({ data: css }) // Remote
+        jest
+          .spyOn(nodeFetch, 'default')
+          .mockResolvedValue({ ok: true, text: async () => css } as any) // Remote
 
         setConfiguration({
           'markdown.marp.themes': ['https://example.com/test.css'],

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -3,7 +3,6 @@ import path from 'path'
 import { URL } from 'url'
 import { promisify, TextDecoder } from 'util'
 import Marp from '@marp-team/marp-core'
-import axios from 'axios'
 import {
   commands,
   workspace,
@@ -13,7 +12,7 @@ import {
   TextDocument,
   Uri,
 } from 'vscode'
-import { marpConfiguration } from './utils'
+import { fetch, marpConfiguration } from './utils'
 
 export enum ThemeType {
   File = 'File',
@@ -143,7 +142,7 @@ export class Themes {
         case ThemeType.File:
           return (await readFile(themePath)).toString()
         case ThemeType.Remote:
-          return (await axios.get(themePath, { timeout: 5000 })).data
+          return await fetch(themePath, { timeout: 5000 })
         case ThemeType.VirtualFS:
           return textDecoder.decode(
             await workspace.fs.readFile(Uri.parse(themePath, true))

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,69 @@
+import { AbortSignal } from 'abort-controller'
+import * as nodeFetch from 'node-fetch'
+import * as utils from './utils'
+
+describe('Utilities', () => {
+  describe('#fetch', () => {
+    beforeEach(() => jest.useFakeTimers())
+
+    afterEach(() => {
+      jest.clearAllTimers()
+      jest.useRealTimers()
+    })
+
+    it('requests remote URL and returns the body as text', async () => {
+      const mocked: Pick<nodeFetch.Response, 'ok' | 'text'> = {
+        ok: true,
+        text: jest.fn(async () => 'result'),
+      }
+
+      const fetch = jest
+        .spyOn(nodeFetch, 'default')
+        .mockResolvedValue(mocked as any)
+
+      const url = 'https://example.com/'
+      const ret = await utils.fetch(url)
+
+      expect(fetch).toHaveBeenCalledWith(url, expect.any(Object))
+      expect(ret).toBe('result')
+    })
+
+    it('throws error if the response status is not 2xx', async () => {
+      const mocked: Pick<nodeFetch.Response, 'ok' | 'text' | 'status'> = {
+        ok: false,
+        text: jest.fn(async () => '404 Not found'),
+        status: 404,
+      }
+
+      jest.spyOn(nodeFetch, 'default').mockResolvedValue(mocked as any)
+
+      await expect(utils.fetch('https://example.com/')).rejects.toThrow(
+        'Failured fetching https://example.com/ (404)'
+      )
+    })
+
+    it('throws error if timed out response (via AbortController)', () =>
+      new Promise<void>((done) => {
+        expect.assertions(1)
+
+        const abortError = new Error('Request aborted')
+        const timeout = 3000
+
+        jest.spyOn(nodeFetch, 'default').mockImplementation((_, opts) => {
+          const signal = opts?.signal as AbortSignal
+
+          return new Promise((_, reject) => {
+            signal.addEventListener('abort', () => reject(abortError))
+          })
+        })
+
+        utils.fetch('https://example.com/', { timeout }).catch((err) => {
+          // eslint-disable-next-line jest/no-conditional-expect
+          expect(err).toStrictEqual(abortError)
+          done()
+        })
+
+        jest.advanceTimersByTime(timeout)
+      }))
+  })
+})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,9 +32,7 @@ export const fetch = (url: string, { timeout = 5000 }: FetchOption = {}) => {
 
   return nodeFetch(url, { signal: controller.signal })
     .then((res) => {
-      if (!res.ok)
-        throw new Error(`Failured fetching ${res.url} (${res.status})`)
-
+      if (!res.ok) throw new Error(`Failured fetching ${url} (${res.status})`)
       return res.text()
     })
     .finally(() => {


### PR DESCRIPTION
Updated to use `node-fetch` instead of `axios`, for fetching remote theme CSS.

[node-fetch](https://bundlephobia.com/package/node-fetch@2.6.1) has very small bundle size than [axios](https://bundlephobia.com/package/axios@0.21.1). By bundling package to the extension, we can expect slightly reducing the cost for installing extension.