### PR TITLE
Handle export into non-file scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Diagnostics for `math` global directive ([#267](https://github.com/marp-team/marp-vscode/pull/267))
   - `define-math-global-directive`: Recommend to declare math typesetting library
   - `ignored-math-global-directive`: Report ignored `math` global directive if disabled math by the extension setting
+- Handle the export command into non-file scheme ([#262](https://github.com/marp-team/marp-vscode/issues/262), [#269](https://github.com/marp-team/marp-vscode/pull/269))
+  - Support direct export from [the remote container](https://code.visualstudio.com/docs/remote/containers) to the local file system
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "license": "MIT",
       "dependencies": {
         "@marp-team/marp-cli": "^1.2.0",
-        "@marp-team/marp-core": "^2.1.0",
-        "tmp": "^0.2.1"
+        "@marp-team/marp-core": "^2.1.0"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.14.8",
@@ -23,7 +22,6 @@
         "@types/lodash.debounce": "^4.0.6",
         "@types/markdown-it": "^12.0.3",
         "@types/node-fetch": "^2.5.12",
-        "@types/tmp": "^0.2.1",
         "@types/vscode": "~1.56.0",
         "@typescript-eslint/eslint-plugin": "^4.28.4",
         "@typescript-eslint/parser": "^4.28.4",
@@ -3018,12 +3016,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-      "dev": true
-    },
-    "node_modules/@types/tmp": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.1.tgz",
-      "integrity": "sha512-7cTXwKP/HLOPVgjg+YhBdQ7bMiobGMuoBmrGmqwIWJv8elC6t1DfVc/mn4fD9UE1IjhwmhaQ5pGVXkmXbH0rhg==",
       "dev": true
     },
     "node_modules/@types/unist": {
@@ -16836,12 +16828,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-      "dev": true
-    },
-    "@types/tmp": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.1.tgz",
-      "integrity": "sha512-7cTXwKP/HLOPVgjg+YhBdQ7bMiobGMuoBmrGmqwIWJv8elC6t1DfVc/mn4fD9UE1IjhwmhaQ5pGVXkmXbH0rhg==",
       "dev": true
     },
     "@types/unist": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@marp-team/marp-cli": "^1.2.0",
         "@marp-team/marp-core": "^2.1.0",
-        "axios": "^0.21.1"
+        "tmp": "^0.2.1"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.14.8",
@@ -23,6 +23,7 @@
         "@types/lodash.debounce": "^4.0.6",
         "@types/markdown-it": "^12.0.3",
         "@types/node-fetch": "^2.5.12",
+        "@types/tmp": "^0.2.1",
         "@types/vscode": "~1.56.0",
         "@typescript-eslint/eslint-plugin": "^4.28.4",
         "@typescript-eslint/parser": "^4.28.4",
@@ -3019,6 +3020,12 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
+    "node_modules/@types/tmp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-7cTXwKP/HLOPVgjg+YhBdQ7bMiobGMuoBmrGmqwIWJv8elC6t1DfVc/mn4fD9UE1IjhwmhaQ5pGVXkmXbH0rhg==",
+      "dev": true
+    },
     "node_modules/@types/unist": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
@@ -3554,14 +3561,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
-      "dependencies": {
-        "follow-redirects": "^1.10.0"
       }
     },
     "node_modules/azure-devops-node-api": {
@@ -6114,25 +6113,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.1.tgz",
       "integrity": "sha512-OMQjaErSFHmHqZe+PSidH5n8j3O0F2DdnVh8JB4j4eUQ2k6KvB0qGfrKIhapvez5JerBbmWkaLYUYWISaESoXg==",
       "dev": true
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
     },
     "node_modules/form-data": {
       "version": "3.0.1",
@@ -16858,6 +16838,12 @@
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
     },
+    "@types/tmp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-7cTXwKP/HLOPVgjg+YhBdQ7bMiobGMuoBmrGmqwIWJv8elC6t1DfVc/mn4fD9UE1IjhwmhaQ5pGVXkmXbH0rhg==",
+      "dev": true
+    },
     "@types/unist": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
@@ -17227,14 +17213,6 @@
             "has-flag": "^3.0.0"
           }
         }
-      }
-    },
-    "axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
-      "requires": {
-        "follow-redirects": "^1.10.0"
       }
     },
     "azure-devops-node-api": {
@@ -19198,11 +19176,6 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.1.tgz",
       "integrity": "sha512-OMQjaErSFHmHqZe+PSidH5n8j3O0F2DdnVh8JB4j4eUQ2k6KvB0qGfrKIhapvez5JerBbmWkaLYUYWISaESoXg==",
       "dev": true
-    },
-    "follow-redirects": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
     },
     "form-data": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -253,7 +253,6 @@
     "@types/lodash.debounce": "^4.0.6",
     "@types/markdown-it": "^12.0.3",
     "@types/node-fetch": "^2.5.12",
-    "@types/tmp": "^0.2.1",
     "@types/vscode": "~1.56.0",
     "@typescript-eslint/eslint-plugin": "^4.28.4",
     "@typescript-eslint/parser": "^4.28.4",
@@ -298,7 +297,6 @@
   },
   "dependencies": {
     "@marp-team/marp-cli": "^1.2.0",
-    "@marp-team/marp-core": "^2.1.0",
-    "tmp": "^0.2.1"
+    "@marp-team/marp-core": "^2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -253,6 +253,7 @@
     "@types/lodash.debounce": "^4.0.6",
     "@types/markdown-it": "^12.0.3",
     "@types/node-fetch": "^2.5.12",
+    "@types/tmp": "^0.2.1",
     "@types/vscode": "~1.56.0",
     "@typescript-eslint/eslint-plugin": "^4.28.4",
     "@typescript-eslint/parser": "^4.28.4",
@@ -297,6 +298,7 @@
   },
   "dependencies": {
     "@marp-team/marp-cli": "^1.2.0",
-    "@marp-team/marp-core": "^2.1.0"
+    "@marp-team/marp-core": "^2.1.0",
+    "tmp": "^0.2.1"
   }
 }

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -140,6 +140,7 @@ export const env = {
 }
 
 export const FileSystem = {
+  copy: jest.fn(),
   stat: jest.fn(async () => ({
     ctime: 0,
     mtime: new Date().getTime(),
@@ -191,6 +192,7 @@ export const window = {
   createTextEditorDecorationType: jest.fn((t) => t),
   onDidChangeActiveTextEditor: jest.fn(),
   showErrorMessage: jest.fn(),
+  showInformationMessage: jest.fn(),
   showQuickPick: jest.fn(),
   showSaveDialog: jest.fn(),
   showTextDocument: jest.fn(async () => ({})),

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -147,6 +147,7 @@ export const FileSystem = {
     type: FileType.File,
   })),
   readFile: jest.fn().mockResolvedValue(new TextEncoder().encode('readFile')),
+  isWritableFileSystem: jest.fn((scheme: string) => scheme === 'file'),
 }
 
 export enum FileType {

--- a/src/commands/export.test.ts
+++ b/src/commands/export.test.ts
@@ -126,7 +126,11 @@ describe('#saveDialog', () => {
   })
 
   it('runs exporting with notification when file path is specified', async () => {
-    const saveURI: any = { path: 'PATH', fsPath: '/tmp/saveTo.pdf' }
+    const saveURI: any = {
+      scheme: 'file',
+      toString: () => 'PATH',
+      fsPath: '/tmp/saveTo.pdf',
+    }
     jest.spyOn(window, 'showSaveDialog').mockImplementation(() => saveURI)
 
     const doExportMock: jest.SpyInstance = jest
@@ -144,7 +148,11 @@ describe('#saveDialog', () => {
 })
 
 describe('#doExport', () => {
-  const saveURI: any = { path: '/tmp/to.pdf', fsPath: '/tmp/to.pdf' }
+  const saveURI: any = {
+    scheme: 'file',
+    path: '/tmp/to.pdf',
+    fsPath: '/tmp/to.pdf',
+  }
   const document: any = {
     uri: { scheme: 'file', path: '/tmp/md.md', fsPath: '/tmp/md.md' },
   }
@@ -207,7 +215,11 @@ describe('#doExport', () => {
     })
 
     it('does not open workspace proxy server while exporting to html', async () => {
-      const saveURIHtml: any = { path: '/tmp/to.html', fsPath: '/tmp/to.html' }
+      const saveURIHtml: any = {
+        scheme: 'file',
+        path: '/tmp/to.html',
+        fsPath: '/tmp/to.html',
+      }
 
       jest.spyOn(marpCli, 'default').mockImplementation()
       jest

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -135,7 +135,7 @@ export const doExport = async (uri: Uri, document: TextDocument) => {
             try {
               await unlink(outputPath)
             } catch (e) {
-              console.warn(e)
+              // no ops
             }
           }
 

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -99,7 +99,7 @@ export const doExport = async (uri: Uri, document: TextDocument) => {
 
     try {
       let outputPath = uri.fsPath
-      const outputToLocalFS = uri.scheme !== 'file'
+      const outputToLocalFS = uri.scheme === 'file'
 
       // NOTE: It may return `undefined` if VS Code does not know about the
       // filesystem. In this case, Marp may be able to write to the output path.

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -109,6 +109,7 @@ export const doExport = async (uri: Uri, document: TextDocument) => {
 
       if (!outputToLocalFS) {
         outputPath = await tmpNamePromise({
+          prefix: 'marp-vscode-tmp',
           postfix: path.extname(uri.path),
         })
       }


### PR DESCRIPTION
The path for exporting slide may become non `file` scheme (e.g. `vscode-local` if used together with Remote extension). This PR is adding support of the export command for non-file scheme.

- If the output path had `file` scheme, Marp CLI tries to export into specified path as same as current.
- If the output path had other URI scheme, Marp CLI tries to export into tmpfile, and copy it to specified path via `vscode.workspace.fs.copy`.
  - In this case, Marp for VS Code will not try to open the output file after exporting.
  - When the URI scheme has marked as readonly, Marp for VS Code will notify users that and not try to export.

An exported slide that has processed in the remote container can save into local file system correctly.

Resolve #262.