### PR TITLE
Add `markdown.marp.pdf.noteAnnotations` config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Auto completion for [`size` global directive](https://github.com/marp-team/marp-core#size-global-directive) ([#276](https://github.com/marp-team/marp-vscode/pull/276))
 - `unknown-size` diagnostic: Notify if the specified size preset was not defined in a theme ([#276](https://github.com/marp-team/marp-vscode/pull/276))
 - Auto-trigger suggestion for value of supported directives ([#277](https://github.com/marp-team/marp-vscode/pull/277))
+- `markdown.marp.pdf.noteAnnotations` config: Add presenter notes to exported PDF as note annotations ([#278](https://github.com/marp-team/marp-vscode/pull/278))
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -163,6 +163,11 @@
           "default": true,
           "description": "Enables the outline extension for Marp Markdown. If enabled, VS Code's outline view will reflect slide splitters, and you can fold regions of the slide content in the editor."
         },
+        "markdown.marp.pdf.noteAnnotations": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Adds [presenter notes](https://marpit.marp.app/usage?id=presenter-notes) to exported PDF as note annotations."
+        },
         "markdown.marp.themes": {
           "type": "array",
           "default": [],

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -9,6 +9,7 @@ const defaultConf: MockedConf = {
   'markdown.marp.enableHtml': false,
   'markdown.marp.exportType': 'pdf',
   'markdown.marp.outlineExtension': true,
+  'markdown.marp.pdf.noteAnnotations': false,
   'window.zoomLevel': 0,
 }
 

--- a/src/option.test.ts
+++ b/src/option.test.ts
@@ -23,8 +23,16 @@ describe('Option', () => {
     it('returns basic options', async () => {
       const opts = await subject({ uri: untitledUri })
 
-      // --allow-local-files
       expect(opts.allowLocalFiles).toBe(true)
+      expect(opts.pdfNotes).toBeUndefined()
+
+      const custom = await subject(
+        { uri: untitledUri },
+        { allowLocalFiles: false, pdfNotes: true }
+      )
+
+      expect(custom.allowLocalFiles).toBe(false)
+      expect(custom.pdfNotes).toBe(true)
     })
 
     it('enables HTML by preference', async () => {

--- a/src/option.ts
+++ b/src/option.ts
@@ -56,12 +56,16 @@ export const marpCoreOptionForPreview = (
 
 export const marpCoreOptionForCLI = async (
   { uri }: TextDocument,
-  { allowLocalFiles = true }: { allowLocalFiles?: boolean } = {}
+  {
+    allowLocalFiles = true,
+    pdfNotes,
+  }: { allowLocalFiles?: boolean; pdfNotes?: boolean } = {}
 ) => {
   const confMdPreview = workspace.getConfiguration('markdown.preview', uri)
 
   const baseOpts = {
     allowLocalFiles,
+    pdfNotes,
     html: enableHtml() || undefined,
     options: {
       markdown: {


### PR DESCRIPTION
Added `markdown.marp.pdf.noteAnnotations` configuration to set whether add presenter notes to exported PDF as note annotations. If enabled, enables Marp CLI's `pdfNotes` option while exporting to PDF.

`pdfNotes: true` changes the priority of export types, so this configuration does never set when tried exporting to non-PDF types.