### PR TITLE
Add definitions for new metadata global directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `unknown-size` diagnostic: Notify if the specified size preset was not defined in a theme ([#276](https://github.com/marp-team/marp-vscode/pull/276))
 - Auto-trigger suggestion for value of supported directives ([#277](https://github.com/marp-team/marp-vscode/pull/277))
 - `markdown.marp.pdf.noteAnnotations` config: Add presenter notes to exported PDF as note annotations ([#278](https://github.com/marp-team/marp-vscode/pull/278))
+- IntelliSense support for new metadata options in [Marp CLI v1.3.0](https://github.com/marp-team/marp-cli/releases/tag/v1.3.0): `author` and `keywords` global directives ([#279](https://github.com/marp-team/marp-vscode/pull/279))
 
 ### Changed
 

--- a/src/directives/definitions.ts
+++ b/src/directives/definitions.ts
@@ -307,6 +307,23 @@ export const builtinDirectives = [
     details: 'https://github.com/marp-team/marp-cli#metadata',
   }),
   createDirectiveInfo({
+    name: 'author',
+    description: 'Set author of the slide deck.',
+    allowed: directiveAlwaysAllowed,
+    providedBy: DirectiveProvidedBy.MarpCLI,
+    type: DirectiveType.Global,
+    details: 'https://github.com/marp-team/marp-cli#metadata',
+  }),
+  createDirectiveInfo({
+    name: 'keywords',
+    description:
+      'Set keywords for the slide deck. It accepts a string consisted by comma-separated keywords, or YAML array of keywords.',
+    allowed: directiveAlwaysAllowed,
+    providedBy: DirectiveProvidedBy.MarpCLI,
+    type: DirectiveType.Global,
+    details: 'https://github.com/marp-team/marp-cli#metadata',
+  }),
+  createDirectiveInfo({
     name: 'url',
     description: 'Set canonical URL for the slide deck.',
     allowed: directiveAlwaysAllowed,

--- a/src/language/completions.test.ts
+++ b/src/language/completions.test.ts
@@ -111,6 +111,7 @@ describe('Auto completions', () => {
 
         expect(labels).toMatchInlineSnapshot(`
           Array [
+            "author",
             "backgroundColor",
             "backgroundImage",
             "backgroundPosition",
@@ -123,6 +124,7 @@ describe('Auto completions', () => {
             "header",
             "headingDivider",
             "image",
+            "keywords",
             "marp",
             "math",
             "paginate",
@@ -151,6 +153,7 @@ describe('Auto completions', () => {
 
         expect(labels).toMatchInlineSnapshot(`
           Array [
+            "author",
             "backgroundColor",
             "backgroundImage",
             "backgroundPosition",
@@ -163,6 +166,7 @@ describe('Auto completions', () => {
             "header",
             "headingDivider",
             "image",
+            "keywords",
             "math",
             "paginate",
             "size",


### PR DESCRIPTION
[Marp CLI v1.3.0](https://github.com/marp-team/marp-cli/releases/tag/v1.3.0) has added new global directives for metadata, `author` and `keywords`. This PR adds definitions for them.