### PR TITLE
Update Web extension limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ It could allow script injection from untrusted Markdown files. Thus, this featur
 You can test installing and using Marp extension in VS Code on the Web environment like [github.dev](https://github.dev). The web extension has many limitations:
 
 - _Export command cannot use_ because it is depending on Marp CLI that is not designed for Web. Please use VS Code that is installed to your local environment or GitHub Codespaces.
-- Currently, VS Code's Markdown engine for the web seems not be able to extend. Thus, Markdown preview and outline extensions are not available on the web for now.
+- Custom theme CSS is not working correctly for now.
 
 ## Contributing
 


### PR DESCRIPTION
We could not confirm working Markdown preview on th web in development, but surprisingly it works in production [github.dev](https://github.dev/yhatt/marp-cli-example)!

![](https://user-images.githubusercontent.com/3993388/132061226-107750af-338e-4c1a-8276-080f4a6c3185.png)

I've updated a limitation of the web extension. Currently custom theme CSS is not working.