### PR TITLE
Refactor theme resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Custom theme CSS support for web extension ([#289](https://github.com/marp-team/marp-vscode/issues/289), [#298](https://github.com/marp-team/marp-vscode/pull/298))
+
 ### Changed
 
 - Completely move build system from rollup to webpack ([#290](https://github.com/marp-team/marp-vscode/pull/290))

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "unified": "^10.1.0",
         "unist-util-visit": "^4.0.0",
         "vsce": "^1.96.3",
+        "vscode-uri": "^3.0.2",
         "webpack": "^5.52.0",
         "webpack-cli": "^4.8.0",
         "yaml": "^2.0.0-5"

--- a/package.json
+++ b/package.json
@@ -299,6 +299,7 @@
     "unified": "^10.1.0",
     "unist-util-visit": "^4.0.0",
     "vsce": "^1.96.3",
+    "vscode-uri": "^3.0.2",
     "webpack": "^5.52.0",
     "webpack-cli": "^4.8.0",
     "yaml": "^2.0.0-5"

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -1,3 +1,5 @@
+import { URI, Utils } from 'vscode-uri'
+
 type MockedConf = Record<string, any>
 
 const defaultVSCodeVersion = 'v1.36.0'
@@ -12,14 +14,6 @@ const defaultConf: MockedConf = {
 }
 
 let currentConf: MockedConf = {}
-
-const uriInstances: Record<string, any> = {}
-const uriInstance = (path: string) =>
-  uriInstances[path] ||
-  (() => {
-    const uri = { path, scheme: 'file', fsPath: path, with: jest.fn(() => uri) }
-    return uri
-  })()
 
 export class CodeAction {
   // command?: Command
@@ -122,11 +116,6 @@ export const RelativePattern = jest.fn()
 
 export const ThemeColor = jest.fn(() => '#000000ff')
 
-export const Uri = {
-  file: uriInstance,
-  parse: uriInstance,
-}
-
 export const commands = {
   executeCommand: jest.fn(async () => {
     // no ops
@@ -197,6 +186,12 @@ export class Memento {
   }
   async update(key: string, value: any) {
     this._map.set(key, value)
+  }
+}
+
+export class Uri extends URI {
+  static joinPath(uri: Uri, ...pathSegments: string[]) {
+    Utils.joinPath(uri, ...pathSegments)
   }
 }
 

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -191,7 +191,7 @@ export class Memento {
 
 export class Uri extends URI {
   static joinPath(uri: Uri, ...pathSegments: string[]) {
-    Utils.joinPath(uri, ...pathSegments)
+    return Utils.joinPath(uri, ...pathSegments)
   }
 }
 

--- a/src/commands/export.test.ts
+++ b/src/commands/export.test.ts
@@ -124,7 +124,7 @@ describe('#saveDialog', () => {
 
     expect(window.showSaveDialog).toHaveBeenCalledWith(
       expect.objectContaining({
-        defaultUri: expect.objectContaining({ fsPath: 'untitled.pdf' }),
+        defaultUri: expect.objectContaining({ path: '/untitled.pdf' }),
       })
     )
   })

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -283,16 +283,17 @@ describe('#extendMarkdownIt', () => {
 
         const markdown = md()
         const mdBody = marpMd('<!--theme: example-->')
+        const mdFileName = path.resolve(baseDir, 'test.css')
         ;(workspace as any).textDocuments = [
           {
             languageId: 'markdown',
             getText: () => mdBody,
-            uri: Uri.parse(baseDir),
-            fileName: path.resolve(baseDir, 'test.css'),
+            uri: Uri.file(mdFileName),
+            fileName: mdFileName,
           } as any,
         ]
 
-        await Promise.all(themes.loadStyles(Uri.parse(baseDir)))
+        await Promise.all(themes.loadStyles(Uri.file(baseDir)))
 
         expect(fsReadFile).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -347,14 +348,7 @@ describe('#extendMarkdownIt', () => {
       })
 
       describe('when the current workspace belongs to the virtual file system', () => {
-        const vfsUri = Object.assign(Uri.parse(baseDir), {
-          scheme: 'vscode-vfs',
-          path: 'vscode-vfs://dummy.host/path/to/workspace',
-          fsPath: '/vscode-vfs/dummy.host/path/to/workspace',
-          toString() {
-            return this.path
-          },
-        })
+        const vfsUri = Uri.parse('vscode-vfs://dummy.host/path/to/workspace')
 
         beforeEach(() => {
           jest
@@ -383,9 +377,7 @@ describe('#extendMarkdownIt', () => {
           await Promise.all(themes.loadStyles(vfsUri))
 
           expect(wsFsReadfile).toHaveBeenCalledWith(
-            expect.objectContaining({
-              path: expect.stringContaining('vscode-vfs://'),
-            })
+            expect.objectContaining({ scheme: 'vscode-vfs' })
           )
           expect(markdown.render(mdBody)).toContain(css)
         })


### PR DESCRIPTION
Refactored theme resolution to use VS Code's `Uri` class instead of an original logic. By this change, custom CSS theme support for web extension becomes working correctly.

Fix #289.