### PR TITLE
Fix regression about export with local custom theme

### DIFF
--- a/src/themes.ts
+++ b/src/themes.ts
@@ -175,7 +175,11 @@ export class Themes {
       }
     })()
 
-    const registeredTheme: Theme = { css, type, path: themePath }
+    const registeredTheme: Theme = {
+      css,
+      type,
+      path: type === ThemeType.File ? themeUri.fsPath : themePath,
+    }
 
     const watcherPattern: GlobPattern | undefined =
       type !== ThemeType.Remote


### PR DESCRIPTION
Store `fsPath` instead of URI string (`file:///`) for management if the custom theme was a local file. Marp CLI cannot parse theme as URI.

Fix #302.