### PR TITLE
Add slide container to fix TypeError in VS Code insider 1.63

### DIFF
--- a/src/option.ts
+++ b/src/option.ts
@@ -44,6 +44,7 @@ export const marpCoreOptionForPreview = (
   if (!cachedPreviewOption) {
     cachedPreviewOption = {
       container: { tag: 'div', id: 'marp-vscode' },
+      slideContainer: { tag: 'div', 'data-marp-vscode-slide-wrapper': '' },
       html: enableHtml() || undefined,
       markdown: {
         breaks: breaks(!!baseOption.breaks),

--- a/style.css
+++ b/style.css
@@ -29,15 +29,14 @@ body.marp-vscode blockquote {
     overflow-y: scroll;
   }
 
-  #marp-vscode svg[data-marpit-svg] {
-    box-shadow: 0 5px 10px rgba(0, 0, 0, 0.25);
-    display: block;
+  #marp-vscode [data-marp-vscode-slide-wrapper] {
     margin: 20px;
   }
 
-  #marp-vscode[data-polyfill] svg[data-marpit-svg] > foreignobject > section {
-    /* Workaround for wrong hit area caused by Chromium's rendering bug */
-    overflow: visible;
+  #marp-vscode svg[data-marpit-svg] {
+    box-shadow: 0 5px 10px rgba(0, 0, 0, 0.25);
+    display: block;
+    margin: 0;
   }
 
   /* Based on https://github.com/microsoft/vscode/blob/master/extensions/markdown-language-features/media/markdown.css */
@@ -68,10 +67,5 @@ body.marp-vscode blockquote {
 @media print {
   body.marp-vscode #code-csp-warning {
     display: none;
-  }
-
-  #marp-vscode[data-polyfill] svg[data-marpit-svg] > foreignobject > section {
-    /* Disable WebKit polyfill */
-    transform: none !important;
   }
 }


### PR DESCRIPTION
The webview for preview has thrown TypeError when VS Code tried to mark Marp slide SVG as the active line.

This error had not effected to the preview until the latest stable VS Code 1.62. But in VS Code insider 1.63, this error will prevent the upcoming preview update.

I've fixed this to wrap SVG with `<div>`, and change the target for tracking active line to added wrapper.