### PR TITLE
Disable source mapping to the slide `<section>` element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Regression about CSS attribute selector with `$=` substring matcher for slide's `class` ([#313](https://github.com/marp-team/marp-vscode/issues/313), [#314](https://github.com/marp-team/marp-vscode/pull/314))
+
 ## v1.4.4 - 2021-11-11
 
 ### Changed

--- a/src/plugins/line-number.ts
+++ b/src/plugins/line-number.ts
@@ -1,6 +1,13 @@
 // Based on the original line-number rendering rule of VS Code.
 // https://github.com/microsoft/vscode/blob/4297ff8195cfabb0f96aefd122a6e88cb6a080bb/extensions/markdown-language-features/src/markdownEngine.ts#L18-L40
 
+// Adding `code-line` class to the Marp slide element `<section>`
+// (`marpit_slide_open` Marpit token type) may bring a side effect to the CSS
+// attribute selector in Marp theme that has expected to use `$=` into the class
+// of slides.
+// https://github.com/marp-team/marp-vscode/issues/313
+const sourceMapIgnoredTypesForElements = ['inline', 'marpit_slide_open']
+
 export default function marpVSCodeLineNumber(md) {
   const { marpit_slide_containers_open } = md.renderer.rules
 
@@ -20,7 +27,10 @@ export default function marpVSCodeLineNumber(md) {
   // Enables line sync per elements
   md.core.ruler.push('marp_vscode_source_map_attr', (state) => {
     for (const token of state.tokens) {
-      if (token.map?.length && token.type !== 'inline') {
+      if (
+        token.map?.length &&
+        !sourceMapIgnoredTypesForElements.includes(token.type)
+      ) {
         token.attrJoin('class', 'code-line')
         token.attrSet('data-line', token.map[0])
       }


### PR DESCRIPTION
Adding `code-line` class to the Marp slide element `<section>` (`marpit_slide_open` Marpit token type) may bring a side effect to the CSS attribute selector in Marp theme that has expected to use `$=` into the class of slides.

Fix #313.