### PR TITLE
Improve initialization of preview styling in VS Code 1.63

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@
 
 - Upgrade Marp Core to [v2.3.0](https://github.com/marp-team/marp-core/releases/tag/v2.3.0) ([#316](https://github.com/marp-team/marp-vscode/pull/316))
 - Upgrade Marp CLI to [v1.5.0](https://github.com/marp-team/marp-cli/releases/tag/v1.5.0) ([#316](https://github.com/marp-team/marp-vscode/pull/316))
+  - Support [`::backdrop` CSS selector provided by Marpit framework](https://marpit.marp.app/inline-svg?id=backdrop-css-selector) in HTML export
 - Upgrade dependent packages to the latest version ([#316](https://github.com/marp-team/marp-vscode/pull/316))
+
+### Fixed
+
+- Improve initialization of preview styling in VS Code 1.63 ([#317](https://github.com/marp-team/marp-vscode/pull/317))
 
 ## v1.4.5 - 2021-11-22
 

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -29,7 +29,7 @@ export default function preview() {
     }
   }
 
-  window.addEventListener('load', updateCallback)
+  window.addEventListener('load', () => window.setTimeout(updateCallback, 100))
   window.addEventListener('vscode.markdown.updateContent', updateCallback)
 
   // Initial update

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -29,6 +29,7 @@ export default function preview() {
     }
   }
 
+  window.addEventListener('load', updateCallback)
   window.addEventListener('vscode.markdown.updateContent', updateCallback)
 
   // Initial update


### PR DESCRIPTION
In upcoming VS Code 1.63, every scripts for Markdown preview,  including Marp, will execute asynchronously. If our initialization script will run before the scripts provided by other extensions, the style removal for to avoid confliction will fail in styles inserted by the scripts.

This PR changes the preview script to call the initialization callback again when fired `window.onload`. A delayed initialization callback in `onload` could wait synchronous execution of every scripts that have loaded asynchrnously.