### PR TITLE
Prevent accidental conflict with globally polluted variables by VS Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent accidental conflict with globally polluted variables by VS Code ([#345](https://github.com/marp-team/marp-vscode/issues/345), [#347](https://github.com/marp-team/marp-vscode/pull/347))
+
 ## v1.5.1 - 2022-04-17
 
 ### Changed

--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -2,7 +2,7 @@ const path = require('path')
 const esbuild = require('esbuild')
 const { ESBuildMinifyPlugin } = require('esbuild-loader')
 
-module.exports = ({ outputPath, production }) => ({
+module.exports = ({ outputPath, production, minimizerFormat }) => ({
   mode: production ? 'production' : 'none',
   resolve: { extensions: ['.ts', '.js'] },
   entry: `./src/${path.basename(outputPath, '.js')}.ts`,
@@ -29,7 +29,13 @@ module.exports = ({ outputPath, production }) => ({
     vscode: 'commonjs vscode',
   },
   optimization: {
-    minimizer: [new ESBuildMinifyPlugin({ target: 'es2019', keepNames: true })],
+    minimizer: [
+      new ESBuildMinifyPlugin({
+        target: 'es2019',
+        format: minimizerFormat,
+        keepNames: true,
+      }),
+    ],
   },
   performance: {
     hints: false,

--- a/webpack.preview.config.js
+++ b/webpack.preview.config.js
@@ -4,7 +4,7 @@ const base = require('./webpack.base.config')
 const outputPath = path.resolve(__dirname, './preview/preview.js')
 
 module.exports = (env) => {
-  const conf = base({ ...env, outputPath })
+  const conf = base({ ...env, outputPath, minimizerFormat: 'iife' })
 
   return {
     ...conf,


### PR DESCRIPTION
See details at https://github.com/marp-team/marp-vscode/issues/345#issuecomment-1106668575.

A minified preview script by Marp may override a global variable `j` provided by VS Code's Markdown preview. It is an important value for incremental update of Markdown contents so we have to prevent overloading in global context by wrapping the build output with IIFE.

Fix #345.