### PR TITLE
Fix the beahavior of auto-scaling component in the preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,19 @@
 # Change Log
 
+> ℹ️ **[v2.x](#v200---2022-06-03) is currently available as pre-released version. Try it and ready for [the next new core](https://marp.app/blog/202205-ecosystem-update)!**
+
 ## [Unreleased]
 
-## v2.0.0 - 2022-06-03
+### Changed
 
-> **This is pre-released version of the major update. Try it and ready for [the next new core](https://marp.app/blog/202205-ecosystem-update)!**
+- Upgrade Marp Core to [v3.2.1](https://github.com/marp-team/marp-core/releases/tag/v3.2.1) ([#361](https://github.com/marp-team/marp-vscode/pull/361))
+- Upgrade Marp CLI to [v2.0.3](https://github.com/marp-team/marp-cli/releases/tag/v2.0.3) ([#361](https://github.com/marp-team/marp-vscode/pull/361))
+
+### Fixed
+
+- Auto-scaling is not working in the preview ([#360](https://github.com/marp-team/marp-vscode/issues/360))
+
+## v2.0.0 - 2022-06-03
 
 ### ⚡️ Breaking
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "@marp-team/marp-cli": "^2.0.1"
+        "@marp-team/marp-cli": "^2.0.3"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.18.2",
-        "@marp-team/marp-core": "^3.2.0",
+        "@marp-team/marp-core": "^3.2.1",
         "@types/express": "^4.17.13",
         "@types/jest": "^27.5.2",
         "@types/lodash.debounce": "^4.0.7",
@@ -2631,9 +2631,9 @@
       }
     },
     "node_modules/@marp-team/marp-cli": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@marp-team/marp-cli/-/marp-cli-2.0.1.tgz",
-      "integrity": "sha512-OCxWwO7mGnCYEcA1NvdAOaWZdVbWCSCS0OX5T1tz05EgCmYe4gcwG9zZwXVcRKkfwu/wDXHdn4BjTkFuSTrWUw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@marp-team/marp-cli/-/marp-cli-2.0.3.tgz",
+      "integrity": "sha512-FgCeUYEddxus0dQV+cOY+GxaCPr1QOGSdey69VhiXx8Pfcnn88g1dT+ODrgVRi+I6/h54/3gOHemcWBynCfYRg==",
       "dependencies": {
         "@marp-team/marp-core": "^3.2.0",
         "@marp-team/marpit": "^2.3.1",
@@ -2641,11 +2641,11 @@
         "cosmiconfig": "^7.0.1",
         "import-from": "^4.0.0",
         "is-wsl": "^2.2.0",
-        "puppeteer-core": "14.1.1",
+        "puppeteer-core": "14.2.1",
         "serve-index": "^1.9.1",
         "tmp": "^0.2.1",
         "v8-compile-cache": "^2.3.0",
-        "ws": "^8.6.0",
+        "ws": "^8.7.0",
         "yargs": "^17.5.1"
       },
       "bin": {
@@ -2656,9 +2656,9 @@
       }
     },
     "node_modules/@marp-team/marp-core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@marp-team/marp-core/-/marp-core-3.2.0.tgz",
-      "integrity": "sha512-LvpEaMhcFG5ZpPvm0FHywtdHQPLL7HGn/tMDHGG4W8P9+pZIHJf7GsgioLwGWpesYudK7cUXicJg4lFj5OuMhg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@marp-team/marp-core/-/marp-core-3.2.1.tgz",
+      "integrity": "sha512-vEePHJvXbb1My0ERJvDoqsUbJQ0uUx0rnnS7VnvMnDPbTuHumnyogEhbIREU3jpYBW7dbkKX9aKCk5kBsquyuw==",
       "dependencies": {
         "@marp-team/marpit": "^2.3.1",
         "@marp-team/marpit-svg-polyfill": "^2.0.0",
@@ -6099,9 +6099,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.982423",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.982423.tgz",
-      "integrity": "sha512-FnVW2nDbjGNw1uD/JRC+9U5768W7e1TfUwqbDTcSsAu1jXFjITSX8w3rkW5FEpHRMPPGpvNSmO1pOpqByiWscA=="
+      "version": "0.0.1001819",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1001819.tgz",
+      "integrity": "sha512-G6OsIFnv/rDyxSqBa2lDLR6thp9oJioLsb2Gl+LbQlyoA9/OBAkrTU9jiCcQ8Pnh7z4d6slDiLaogR5hzgJLmQ=="
     },
     "node_modules/diff": {
       "version": "5.1.0",
@@ -14681,13 +14681,13 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-14.1.1.tgz",
-      "integrity": "sha512-DWLzFcawn1ANg2Q06Eieing4Y0fdNI7miax3f+wEbdROzlMG4yXIWzmT6XTKyFyqOjMhW5QNIDdFJftK6oP4og==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-14.2.1.tgz",
+      "integrity": "sha512-Hl5vaLGVr4z3fhlWILgm143yz08K5LyljavaEpcMZdSS9BQNRO3MdpHARXSgKddg/LkfSdOCbDf6w+suES0MMQ==",
       "dependencies": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.982423",
+        "devtools-protocol": "0.0.1001819",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.1",
         "pkg-dir": "4.2.0",
@@ -14696,30 +14696,10 @@
         "rimraf": "3.0.2",
         "tar-fs": "2.1.1",
         "unbzip2-stream": "1.4.3",
-        "ws": "8.6.0"
+        "ws": "8.7.0"
       },
       "engines": {
         "node": ">=14.1.0"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/ws": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.6.0.tgz",
-      "integrity": "sha512-AzmM3aH3gk0aX7/rZLYvjdvZooofDu3fFOzGqcSnQ1tOcTWwhM/o+q++E8mAyVVIyUdajrkzWUGftaVSDLn1bw==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/qs": {
@@ -20359,9 +20339,9 @@
       }
     },
     "@marp-team/marp-cli": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@marp-team/marp-cli/-/marp-cli-2.0.1.tgz",
-      "integrity": "sha512-OCxWwO7mGnCYEcA1NvdAOaWZdVbWCSCS0OX5T1tz05EgCmYe4gcwG9zZwXVcRKkfwu/wDXHdn4BjTkFuSTrWUw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@marp-team/marp-cli/-/marp-cli-2.0.3.tgz",
+      "integrity": "sha512-FgCeUYEddxus0dQV+cOY+GxaCPr1QOGSdey69VhiXx8Pfcnn88g1dT+ODrgVRi+I6/h54/3gOHemcWBynCfYRg==",
       "requires": {
         "@marp-team/marp-core": "^3.2.0",
         "@marp-team/marpit": "^2.3.1",
@@ -20369,18 +20349,18 @@
         "cosmiconfig": "^7.0.1",
         "import-from": "^4.0.0",
         "is-wsl": "^2.2.0",
-        "puppeteer-core": "14.1.1",
+        "puppeteer-core": "14.2.1",
         "serve-index": "^1.9.1",
         "tmp": "^0.2.1",
         "v8-compile-cache": "^2.3.0",
-        "ws": "^8.6.0",
+        "ws": "^8.7.0",
         "yargs": "^17.5.1"
       }
     },
     "@marp-team/marp-core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@marp-team/marp-core/-/marp-core-3.2.0.tgz",
-      "integrity": "sha512-LvpEaMhcFG5ZpPvm0FHywtdHQPLL7HGn/tMDHGG4W8P9+pZIHJf7GsgioLwGWpesYudK7cUXicJg4lFj5OuMhg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@marp-team/marp-core/-/marp-core-3.2.1.tgz",
+      "integrity": "sha512-vEePHJvXbb1My0ERJvDoqsUbJQ0uUx0rnnS7VnvMnDPbTuHumnyogEhbIREU3jpYBW7dbkKX9aKCk5kBsquyuw==",
       "requires": {
         "@marp-team/marpit": "^2.3.1",
         "@marp-team/marpit-svg-polyfill": "^2.0.0",
@@ -23071,9 +23051,9 @@
       "dev": true
     },
     "devtools-protocol": {
-      "version": "0.0.982423",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.982423.tgz",
-      "integrity": "sha512-FnVW2nDbjGNw1uD/JRC+9U5768W7e1TfUwqbDTcSsAu1jXFjITSX8w3rkW5FEpHRMPPGpvNSmO1pOpqByiWscA=="
+      "version": "0.0.1001819",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1001819.tgz",
+      "integrity": "sha512-G6OsIFnv/rDyxSqBa2lDLR6thp9oJioLsb2Gl+LbQlyoA9/OBAkrTU9jiCcQ8Pnh7z4d6slDiLaogR5hzgJLmQ=="
     },
     "diff": {
       "version": "5.1.0",
@@ -29316,13 +29296,13 @@
       }
     },
     "puppeteer-core": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-14.1.1.tgz",
-      "integrity": "sha512-DWLzFcawn1ANg2Q06Eieing4Y0fdNI7miax3f+wEbdROzlMG4yXIWzmT6XTKyFyqOjMhW5QNIDdFJftK6oP4og==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-14.2.1.tgz",
+      "integrity": "sha512-Hl5vaLGVr4z3fhlWILgm143yz08K5LyljavaEpcMZdSS9BQNRO3MdpHARXSgKddg/LkfSdOCbDf6w+suES0MMQ==",
       "requires": {
         "cross-fetch": "3.1.5",
         "debug": "4.3.4",
-        "devtools-protocol": "0.0.982423",
+        "devtools-protocol": "0.0.1001819",
         "extract-zip": "2.0.1",
         "https-proxy-agent": "5.0.1",
         "pkg-dir": "4.2.0",
@@ -29331,15 +29311,7 @@
         "rimraf": "3.0.2",
         "tar-fs": "2.1.1",
         "unbzip2-stream": "1.4.3",
-        "ws": "8.6.0"
-      },
-      "dependencies": {
-        "ws": {
-          "version": "8.6.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-8.6.0.tgz",
-          "integrity": "sha512-AzmM3aH3gk0aX7/rZLYvjdvZooofDu3fFOzGqcSnQ1tOcTWwhM/o+q++E8mAyVVIyUdajrkzWUGftaVSDLn1bw==",
-          "requires": {}
-        }
+        "ws": "8.7.0"
       }
     },
     "qs": {

--- a/package.json
+++ b/package.json
@@ -259,7 +259,7 @@
   },
   "devDependencies": {
     "@babel/preset-env": "^7.18.2",
-    "@marp-team/marp-core": "^3.2.0",
+    "@marp-team/marp-core": "^3.2.1",
     "@types/express": "^4.17.13",
     "@types/jest": "^27.5.2",
     "@types/lodash.debounce": "^4.0.7",
@@ -311,6 +311,6 @@
     "yaml": "^2.1.1"
   },
   "dependencies": {
-    "@marp-team/marp-cli": "^2.0.1"
+    "@marp-team/marp-cli": "^2.0.3"
   }
 }


### PR DESCRIPTION
- Applied a patch from [Marp Core v3.2.1](https://github.com/marp-team/marp-core/releases/tag/v3.2.1).
  - https://github.com/marp-team/marp-core/pull/305
  - Use `browser()` to apply Web component correctly. By calling `update()` in the returned object, `<pre is="marp-pre">` in the document will change to `<marp-pre>`. `pre` tag is a one of elements that has not supported `is` attribute due to security reason.

* `is` attribute in VS Code's incremental DOM update has a different problem.
  - The node has to replace to upgrade into the custom element. `setAttribute('is', 'marp-xxx')` to the same node does not trigger of upgrade. VS Code's preview updation by morphdom is not handling this case.
  - :arrow_right: When brought incremental update of Markdown, Marp for VS Code will find out not-upgraded elements and replace the node into the custom element by assigning the same value of `outerHTML` by self. There are no effects to already processed nodes so it would bring less performance hit.

Fix #360.