### PR TITLE
Removed `markdown.marp.toolbarButtonForQuickPick` setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 - Upgrade Marp CLI to [v2.2.2](https://github.com/marp-team/marp-cli/releases/tag/v2.2.2) ([#390](https://github.com/marp-team/marp-vscode/pull/390))
 - Upgrade Node.js and dependent packages ([#390](https://github.com/marp-team/marp-vscode/pull/390))
 
+### Removed
+
+- `markdown.marp.toolbarButtonForQuickPick` setting ([#391](https://github.com/marp-team/marp-vscode/pull/391))
+  - The toolbar button still can hide from VS Code user interface: https://code.visualstudio.com/updates/v1_72#_hide-actions-from-tool-bars
+
 ## v2.3.0 - 2022-09-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Removed
 
-- `markdown.marp.toolbarButtonForQuickPick` setting ([#391](https://github.com/marp-team/marp-vscode/pull/391))
+- `markdown.marp.toolbarButtonForQuickPick` setting ([#385](https://github.com/marp-team/marp-vscode/issues/385), [#391](https://github.com/marp-team/marp-vscode/pull/391))
   - The toolbar button still can hide from VS Code user interface: https://code.visualstudio.com/updates/v1_72#_hide-actions-from-tool-bars
 
 ## v2.3.0 - 2022-09-24

--- a/package.json
+++ b/package.json
@@ -201,11 +201,6 @@
           "items": {
             "type": "string"
           }
-        },
-        "markdown.marp.toolbarButtonForQuickPick": {
-          "type": "boolean",
-          "default": true,
-          "description": "Shows editor toolbar button to Markdown document, for accessing quick pick of Marp commands."
         }
       }
     },
@@ -221,7 +216,7 @@
         {
           "command": "markdown.marp.showQuickPick",
           "group": "navigation",
-          "when": "config.markdown.marp.toolbarButtonForQuickPick && editorLangId == markdown"
+          "when": "editorLangId == markdown"
         }
       ],
       "file/newFile": [


### PR DESCRIPTION
VS Code 1.72 and later have supported to hide toolbar icon provided by extension.
https://code.visualstudio.com/updates/v1_72#_hide-actions-from-tool-bars

Close #385.