### PR TITLE
Make v2 release stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Change Log
 
-> ℹ️ **[v2.x](#v200---2022-06-03) is currently available as pre-released version. Try it and ready for [the next new core](https://marp.app/blog/202205-ecosystem-update)!**
-
 ## [Unreleased]
+
+> 🆙 **This is a first stable release of v2.x!** You can see differences from v1 at [#392](https://github.com/marp-team/marp-vscode/pull/392).
 
 ### Breaking
 
+- Marp for VS Code v2 has made as stable release ([#392](https://github.com/marp-team/marp-vscode/pull/392))
 - VS Code 1.72 and later required ([#390](https://github.com/marp-team/marp-vscode/pull/390))
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -229,8 +229,7 @@
   },
   "private": true,
   "vsce": {
-    "yarn": false,
-    "preRelease": true
+    "yarn": false
   },
   "prettier": {
     "semi": false,

--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -9,6 +9,7 @@ module.exports = ({ outputPath, production, minimizerFormat }) => ({
       // Marp Core (CJS) is not compatible with ESM default export
       // https://github.com/marp-team/marp-core/issues/322
       'emoji-regex$': require.resolve('emoji-regex/index.js'),
+      twemoji$: require.resolve('twemoji/dist/twemoji.npm.js'),
     },
     extensions: ['.ts', '.js'],
   },


### PR DESCRIPTION
> We have recognized that Marp users who use GUI are including a lot of beginners and non-developers, so we think we should provide enough window time for them to review breaking changes.
>
> _&mdash; [Ecosystem update: Marp Core v3 & Slide transitions in CLI v2 | Blog | Marp](https://marp.app/blog/202205-ecosystem-update#opt-in-the-new-core-in-a-vs-code-extension:~:text=We%20have%20recognized%20that%20Marp%20users%20who%20use%20GUI%20are%20including%20a%20lot%20of%20beginners%20and%20non%2Ddevelopers%2C%20so%20we%20think%20we%20should%20provide%20enough%20window%20time%20for%20them%20to%20review%20breaking%20changes.)_

We have taken enough transition period about half year, and ready to make stable v2 release. The next minor release v2.4.0 will be a first stable release of v2.


## Difference from v1

See also [release notes](https://github.com/marp-team/marp-vscode/releases).

### Breaking

- VS Code 1.72 or later is required

### Core update

- [Marp for VS Code v2 is using current version of Marp Core (v3)](https://marp.app/blog/202205-ecosystem-update#notable-changes)
  - Changed the default math typesetting library, from KaTeX to MathJax
  - Updated `default` theme to follow GitHub style
  - CSS styling update for auto-scaled component
  - URL without HTTP(S) scheme does no longer auto-linkify

### Added settings

* `markdown.marp.pdf.outlines` setting
  - Export PDF with outlines (also known as bookmarks)

- [EXPERIMENTAL] `markdown.marp.strictPathResolutionDuringExport` setting
  - It will apply path resolution based on VS Code workspace, to resources used by Markdown, and make more compatible export result with VS Code Markdown preview

### Removed settings

- `markdown.marp.toolbarButtonForQuickPick` setting
  - [The toolbar button still can hide from VS Code user interface](https://code.visualstudio.com/updates/v1_72#_hide-actions-from-tool-bars)

### Deprecated

- Shorthanded image syntax for setting text color and background color (`![](color)` and `![bg](color)`)
  - You can fix easily from light bulb menu on VS Code