### PR TITLE
Apply VS Code's link renderer when rendering Markdown in preview panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   - Support `paginate: skip` and `paginate: hold` from Marpit framework [v2.5.0](https://github.com/marp-team/marpit/releases/v2.5.0)
 - Upgrade Marp CLI to [v3.2.0](https://github.com/marp-team/marp-cli/releases/tag/v3.2.0) ([#427](https://github.com/marp-team/marp-vscode/pull/427))
 
+### Fixed
+
+- Apply VS Code's link renderer when rendering Markdown in preview ([#428](https://github.com/marp-team/marp-vscode/pull/428))
+
 ## v2.6.0 - 2023-04-16
 
 ### Added

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -88,8 +88,9 @@ export function extendMarkdownIt(md: any) {
         }
       }
 
-      // Use image stabilizer and link normalizer from VS Code
+      // Use image stabilizer, link renderer and link normalizer from VS Code
       marp.markdown.renderer.rules.image = md.renderer.rules.image
+      marp.markdown.renderer.rules.link_open = md.renderer.rules.link_open
       marp.markdown.normalizeLink = md.normalizeLink
 
       // validateLink prefers Marp's default. If overridden by VS Code's it,


### PR DESCRIPTION
VS Code has owned link renderer to add `data-href` attribute to every hyperlinks.
https://github.com/microsoft/vscode/blob/6a025483bda7044f1949ca9ee027969eb917de80/extensions/markdown-language-features/src/markdownEngine.ts#L330-L346

This was not important in not so long ago because the Electron frame could trap every page navigations. But in recent VS Code, it becomes important to trap `<a>` links because VS Code covers Web now.

We've updated to apply VS Code's link renderer when rendering Marp Markdown in the preview. `<a href="https://example.com">` will render as `<a href="https://example.com" data-href="https://example.com">`, and VS Code built-in preview becomes able to trap links rendered by Marp.
https://github.com/microsoft/vscode/blob/6a025483bda7044f1949ca9ee027969eb917de80/extensions/markdown-language-features/preview-src/index.ts#L333-L348

Resolves marp-team/marp#461.