### PR TITLE
Update IntelliSense for `paginate` directive: Suggest new keywords `skip` and `hold`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Upgrade Marp Core to [v3.8.0](https://github.com/marp-team/marp-core/releases/tag/v3.8.0) ([#427](https://github.com/marp-team/marp-vscode/pull/427))
   - Support `paginate: skip` and `paginate: hold` from Marpit framework [v2.5.0](https://github.com/marp-team/marpit/releases/v2.5.0)
 - Upgrade Marp CLI to [v3.2.0](https://github.com/marp-team/marp-cli/releases/tag/v3.2.0) ([#427](https://github.com/marp-team/marp-vscode/pull/427))
+- Update IntelliSense for `paginate` directive: Suggest new keywords `skip` and `hold` ([#429](https://github.com/marp-team/marp-vscode/pull/429))
 
 ### Fixed
 

--- a/src/directives/definitions.ts
+++ b/src/directives/definitions.ts
@@ -143,7 +143,18 @@ export const builtinDirectives = [
   // Marpit local directives
   createDirectiveInfo({
     name: 'paginate',
-    description: 'Show page number on the slide if set `true`.',
+    description: dedent(`
+      Control the slide page number.
+
+      Use the boolean values \`true\` and \`false\` to control the visibility of the page number on the slide.
+
+      You can also manage the page number increment behavior using the additional keywords \`skip\` and \`hold\`.
+
+      - \`false\`: Hide the page number. (default)
+      - \`true\`: Show the page number.
+      - \`skip\`: Hide the page number and prevent its increment.
+      - \`hold\`: Show the page number, but prevent increment even on the following page(s).
+    `),
     allowed: directiveAlwaysAllowed,
     providedBy: DirectiveProvidedBy.Marpit,
     type: DirectiveType.Local,

--- a/src/language/completions.test.ts
+++ b/src/language/completions.test.ts
@@ -279,8 +279,8 @@ describe('Auto completions', () => {
       })
     })
 
-    describe('Boolean suggestion', () => {
-      it('suggests boolean values when the cursor is on paginate directive', async () => {
+    describe('Paginate directive suggestion', () => {
+      it('suggests acceptable values for paginate directive when the cursor is on the directive', async () => {
         const doc = setDocument('---\nmarp: true\npaginate: \n---')
         const list = (await provideCompletionItems()(
           doc,
@@ -294,6 +294,8 @@ describe('Auto completions', () => {
         expect(labels).toMatchInlineSnapshot(`
           [
             "false",
+            "hold",
+            "skip",
             "true",
           ]
         `)

--- a/src/language/completions.ts
+++ b/src/language/completions.ts
@@ -117,7 +117,7 @@ class CompletionProvider {
   getCompletionList() {
     return (
       this.completionThemes() ||
-      this.completionBoolean() ||
+      this.completionPaginate() ||
       this.completionMath() ||
       this.completionSizePreset() ||
       this.completionBuiltInTransitions() ||
@@ -144,18 +144,33 @@ class CompletionProvider {
     }
   }
 
-  private completionBoolean() {
+  private completionPaginate() {
     if (this.isCursorOnDirective('paginate', DirectiveType.Local)) {
       return new CompletionList([
         {
-          detail: 'Boolean',
+          detail: 'Keyword for paginate directive',
           kind: CompletionItemKind.EnumMember,
           label: 'true',
+          documentation: 'Show the page number.',
         },
         {
-          detail: 'Boolean',
+          detail: 'Keyword for paginate directive',
           kind: CompletionItemKind.EnumMember,
           label: 'false',
+          documentation: 'Hide the page number.',
+        },
+        {
+          detail: 'Keyword for paginate directive',
+          kind: CompletionItemKind.EnumMember,
+          label: 'skip',
+          documentation: 'Hide the page number and prevent its increment.',
+        },
+        {
+          detail: 'Keyword for paginate directive',
+          kind: CompletionItemKind.EnumMember,
+          label: 'hold',
+          documentation:
+            'Show the page number, but prevent increment even on the following page(s).',
         },
       ])
     }


### PR DESCRIPTION
Added suggestion for additional keywords `skip` and `hold`, that was supported by Marpit framework v2.5.0.