### PR TITLE
Add IntelliSense definition for `lang` global directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Upgrade Marp CLI to [v3.4.0](https://github.com/marp-team/marp-cli/releases/tag/v3.4.0) ([#444](https://github.com/marp-team/marp-vscode/pull/444))
 - Upgrade dependent packages to the latest version ([#445](https://github.com/marp-team/marp-vscode/pull/445))
 
+### Added
+
+- IntelliSense definition for `lang` global directive ([#430](https://github.com/marp-team/marp-vscode/issues/430), [#446](https://github.com/marp-team/marp-vscode/pull/446))
+
 ### Fixed
 
 - Disappeared inline elements with `position: relative` that are the direct children of the slide ([#442](https://github.com/marp-team/marp-vscode/issues/442), [#443](https://github.com/marp-team/marp-vscode/pull/443))

--- a/jest.config.js
+++ b/jest.config.js
@@ -42,6 +42,7 @@ module.exports = {
   coveragePathIgnorePatterns: ['/node_modules/', '.*\\.d\\.ts'],
   coverageThreshold: { global: { lines: 95 } },
   preset: 'ts-jest/presets/js-with-babel',
+  prettierPath: null,
   setupFiles: ['<rootDir>/jest.setup.js'],
   testEnvironment: 'node',
   transformIgnorePatterns: [`/node_modules/(?!${esModules.join('|')})`],

--- a/src/directives/definitions.ts
+++ b/src/directives/definitions.ts
@@ -98,6 +98,13 @@ export const builtinDirectives = [
     completable: true,
   }),
   createDirectiveInfo({
+    name: 'lang',
+    description: 'Set the `lang` attribute of the entire slide deck.',
+    allowed: directiveAlwaysAllowed,
+    providedBy: DirectiveProvidedBy.Marpit,
+    type: DirectiveType.Global,
+  }),
+  createDirectiveInfo({
     name: 'style',
     description: dedent(`
       Specify CSS for tweaking theme.

--- a/src/language/completions.test.ts
+++ b/src/language/completions.test.ts
@@ -112,32 +112,33 @@ describe('Auto completions', () => {
         const labels = list.items.map((item) => item.label).sort()
 
         expect(labels).toMatchInlineSnapshot(`
-          [
-            "author",
-            "backgroundColor",
-            "backgroundImage",
-            "backgroundPosition",
-            "backgroundRepeat",
-            "backgroundSize",
-            "class",
-            "color",
-            "description",
-            "footer",
-            "header",
-            "headingDivider",
-            "image",
-            "keywords",
-            "marp",
-            "math",
-            "paginate",
-            "size",
-            "style",
-            "theme",
-            "title",
-            "transition",
-            "url",
-          ]
-        `)
+[
+  "author",
+  "backgroundColor",
+  "backgroundImage",
+  "backgroundPosition",
+  "backgroundRepeat",
+  "backgroundSize",
+  "class",
+  "color",
+  "description",
+  "footer",
+  "header",
+  "headingDivider",
+  "image",
+  "keywords",
+  "lang",
+  "marp",
+  "math",
+  "paginate",
+  "size",
+  "style",
+  "theme",
+  "title",
+  "transition",
+  "url",
+]
+`)
 
         // The insert text has semicolon
         expect(list.items[0].insertText).toBe(`${list.items[0].label}: `)
@@ -155,31 +156,32 @@ describe('Auto completions', () => {
         const labels = list.items.map((item) => item.label).sort()
 
         expect(labels).toMatchInlineSnapshot(`
-          [
-            "author",
-            "backgroundColor",
-            "backgroundImage",
-            "backgroundPosition",
-            "backgroundRepeat",
-            "backgroundSize",
-            "class",
-            "color",
-            "description",
-            "footer",
-            "header",
-            "headingDivider",
-            "image",
-            "keywords",
-            "math",
-            "paginate",
-            "size",
-            "style",
-            "theme",
-            "title",
-            "transition",
-            "url",
-          ]
-        `)
+[
+  "author",
+  "backgroundColor",
+  "backgroundImage",
+  "backgroundPosition",
+  "backgroundRepeat",
+  "backgroundSize",
+  "class",
+  "color",
+  "description",
+  "footer",
+  "header",
+  "headingDivider",
+  "image",
+  "keywords",
+  "lang",
+  "math",
+  "paginate",
+  "size",
+  "style",
+  "theme",
+  "title",
+  "transition",
+  "url",
+]
+`)
         expect(labels).not.toContain('marp')
       })
 


### PR DESCRIPTION
Updated Marpit framework, Marp Core, and Marp CLI are supporting `lang` global directive for setting the language of Markdown document. We added IntelliSense support for `lang` global directive.

![](https://github.com/marp-team/marp-vscode/assets/3993388/800430d9-c6e9-4fef-9d6b-7269469f7238)

By changing the `lang` directive, Markdown author can check out slight changes in a preview pane.

|`lang`|Screenshot|
|:---:|:---:|
|**`en`**|![en](https://github.com/marp-team/marp-vscode/assets/3993388/8c4de0b8-4667-484b-a109-8db578f2aefd)|
|**`de`**|![de](https://github.com/marp-team/marp-vscode/assets/3993388/ffe3c59b-91e5-461b-b598-93608c05dcef)|
|**`zh`**|![zh](https://github.com/marp-team/marp-vscode/assets/3993388/b0bbc702-eb04-40cb-94b2-886e959e33cd)|
|**`ja`**|![ja](https://github.com/marp-team/marp-vscode/assets/3993388/84900582-9264-40a9-af63-5850ffbc4c8d)|

Closes #430.