### PR TITLE
[v3] `markdown.marp.html` setting to control which HTML elements are rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@
 - Upgrade Marp Core to [v4.0.1](https://github.com/marp-team/marp-core/releases/v4.0.1) ([#472](https://github.com/marp-team/marp-vscode/pull/472), [#474](https://github.com/marp-team/marp-vscode/pull/474))
 - Upgrade Marp CLI to [v4.0.4](https://github.com/marp-team/marp-cli/releases/v4.0.4) ([#473](https://github.com/marp-team/marp-vscode/pull/473), [#474](https://github.com/marp-team/marp-vscode/pull/474))
 
+### Added
+
+- `markdown.marp.html` setting to control rendering HTML within Marp Markdown ([#476](https://github.com/marp-team/marp-vscode/pull/476))
+
+### Deprecated
+
+- `markdown.marp.enableHtml` setting ([#476](https://github.com/marp-team/marp-vscode/pull/476))
+
 ### Changed
 
 - Upgrade development Node.js and dependent packages to the latest version ([#474](https://github.com/marp-team/marp-vscode/pull/474))

--- a/README.md
+++ b/README.md
@@ -205,11 +205,16 @@ Features may be restricted are marked by the shield icon 🛡️ in this documen
 
 [workspace trust]: https://code.visualstudio.com/docs/editor/workspace-trust
 
-#### Enable HTML in Marp Markdown 🛡️
+#### HTML elements in Markdown 🛡️
 
-You can enable previsualization of HTML code within Marp Markdown with the `markdown.marp.enableHtml` option.
+In the trusted workspace, if Marp Markdown was included HTML elements, [only selectivity HTML elements by Marp](https://github.com/marp-team/marp-core/blob/main/src/html/allowlist.ts) can render by default. You can control which HTML elements will be rendered by setting the `markdown.marp.html` option,
 
-It could allow script injection from untrusted Markdown files. Thus, this feature is disabled as a default and will be _always ignored in the untrusted workspace_. Use with caution.
+You can control which HTML elements will be rendered by setting the `markdown.marp.html` option. You can set it as `all` to allow all HTML elements, but could allow script injection from untrusted Markdown files. Use with caution.
+
+In the untrusted workspace, HTML elements in Marp Markdown will be always ignored regardless of the selected option in `markdown.marp.html`.
+
+> [!NOTE]
+> A legacy setting `markdown.marp.enableHtml` is deprecated since v2. Please use `markdown.marp.html` instead.
 
 ## Web extension
 

--- a/package.json
+++ b/package.json
@@ -120,9 +120,19 @@
           "description": "Sets the custom path for Chrome or Chromium-based browser to export PDF, PPTX, and image. If it's empty, Marp will find out the installed Google Chrome / Chromium / Microsoft Edge."
         },
         "markdown.marp.enableHtml": {
-          "type": "boolean",
-          "default": false,
-          "description": "Enables all HTML elements in Marp Markdown. This setting is working only in the trusted workspace."
+          "type": "string",
+          "enum": [
+            "off",
+            "default",
+            "all"
+          ],
+          "markdownEnumDescriptions": [
+            "Disable all HTML elements, including originally allowed HTML elements by Marp.",
+            "Enable only selectively enabled HTML elements by Marp. _([See the list of HTML elements](https://github.com/marp-team/marp-core/blob/main/src/html/allowlist.ts))_",
+            "Enable all HTML elements. This setting may become the slide rendering insecure."
+          ],
+          "default": "default",
+          "description": "Sets which HTML elements in Marp Markdown are enabled in rendered slides. If the workspace is not trusted, this setting treats as always \"off\"."
         },
         "markdown.marp.exportType": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
       "supported": "limited",
       "description": "Workspace trust is required for exporting slide deck, and using themes configured in the workspace.",
       "restrictedConfigurations": [
+        "markdown.marp.html",
         "markdown.marp.enableHtml",
         "markdown.marp.themes"
       ]
@@ -119,7 +120,7 @@
           "default": "",
           "description": "Sets the custom path for Chrome or Chromium-based browser to export PDF, PPTX, and image. If it's empty, Marp will find out the installed Google Chrome / Chromium / Microsoft Edge."
         },
-        "markdown.marp.enableHtml": {
+        "markdown.marp.html": {
           "type": "string",
           "enum": [
             "off",
@@ -132,7 +133,7 @@
             "Enable all HTML elements. This setting may become the slide rendering insecure."
           ],
           "default": "default",
-          "description": "Sets which HTML elements in Marp Markdown are enabled in rendered slides. If the workspace is not trusted, this setting treats as always \"off\"."
+          "description": "Sets which HTML elements within Marp Markdown are enabled in rendered slides. If the workspace is not trusted, this setting treats as always \"off\"."
         },
         "markdown.marp.exportType": {
           "type": "string",
@@ -207,6 +208,12 @@
           "items": {
             "type": "string"
           }
+        },
+        "markdown.marp.enableHtml": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enables all HTML elements in Marp Markdown. This setting is working only in the trusted workspace.",
+          "deprecationMessage": "The setting \"markdown.marp.enableHtml\" is deprecated. Please use \"markdown.marp.html\" instead."
         }
       }
     },

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -7,6 +7,7 @@ const defaultConf: MockedConf = {
   'markdown.marp.breaks': 'on',
   'markdown.marp.chromePath': '',
   'markdown.marp.enableHtml': false,
+  'markdown.marp.html': 'default',
   'markdown.marp.exportType': 'pdf',
   'markdown.marp.outlineExtension': true,
   'markdown.marp.pdf.noteAnnotations': false,
@@ -227,7 +228,7 @@ export const window = {
   showQuickPick: jest.fn(),
   showSaveDialog: jest.fn(),
   showTextDocument: jest.fn(async () => ({})),
-  showWarningMessage: jest.fn(),
+  showWarningMessage: jest.fn(async () => undefined),
   withProgress: jest.fn(),
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import { detectMarpFromMarkdown, marpConfiguration } from './utils'
 const shouldRefreshConfs = [
   'markdown.marp.breaks',
   'markdown.marp.enableHtml',
+  'markdown.marp.html',
   'markdown.marp.mathTypesetting',
   'markdown.marp.outlineExtension',
   'markdown.marp.themes',

--- a/src/option.test.ts
+++ b/src/option.test.ts
@@ -168,9 +168,9 @@ describe('Option', () => {
 
       afterEach(() => isTrustedMock?.mockRestore())
 
-      it('ignores potentially malicious options', async () => {
-        setConfiguration({ 'markdown.marp.enableHtml': true })
-        expect((await subject({ uri: untitledUri })).html).toBeUndefined()
+      it('disallows potentially malicious options', async () => {
+        setConfiguration({ 'markdown.marp.html': 'all' })
+        expect((await subject({ uri: untitledUri })).html).toBe(false)
       })
     })
   })

--- a/src/option.ts
+++ b/src/option.ts
@@ -30,8 +30,19 @@ const breaks = (inheritedValue: boolean): boolean => {
   }
 }
 
-const enableHtml = () =>
-  marpConfiguration().get<boolean>('enableHtml') && workspace.isTrusted
+const enableHtml = () => {
+  if (workspace.isTrusted) {
+    const conf = marpConfiguration().get<boolean | string>('enableHtml')
+
+    // Boolean is for v1 backward compatibility
+    if (conf === 'all' || conf === true) return true
+    if (conf === 'off' || conf === false) return false
+
+    return undefined
+  } else {
+    return false
+  }
+}
 
 const math = () => {
   const conf = mathTypesettingConfiguration()


### PR DESCRIPTION
Marp Core v4 has been allowed many HTML elements by default, and the new major version of Marp for VS Code is going to respect. However, `markdown.marp.enableHtml` should set a boolean value so cannot set an intermediate state.

Thus, we provide a new option **`markdown.marp.html`** instead `markdown.marp.enableHtml`:

- `off`: HTML elements are completely disabled.
- `default`: Some allowlisted HTML elements by Marp Core are allowed. (= `markdown.marp.enableHtml: false`, default)
- `all`: All HTML elements are enabled. (= `markdown.marp.enableHtml: true`)

In the untrusted workspace, HTML elements will be completely disabled for security.

Currently if `markdown.marp.enableHtml` has been set as `true`, we still recognize it and render all HTML elements as same as v2, but the deprecation warning will show. We will retain this behavior for a certain period to encourage users to update their settings.