### PR TITLE
[v3] `markdown.marp.browser` and `markdown.marp.browserPath` settings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,10 @@ commands:
             - run: npm run check:audit
 
   test:
+    parameters:
+      run-in-band:
+        type: boolean
+        default: false
     steps:
       - checkout
       - install
@@ -66,7 +70,7 @@ commands:
 
       - run:
           name: Jest
-          command: npm run test:unit:coverage -- --ci --maxWorkers=2 --reporters=default --reporters=jest-junit
+          command: npm run test:unit:coverage -- --ci --maxWorkers=2 <<# parameters.run-in-band >>-i<</ parameters.run-in-band >> --reporters=default --reporters=jest-junit
           environment:
             JEST_JUNIT_OUTPUT_DIR: tmp/test-results
 
@@ -90,14 +94,16 @@ jobs:
       name: node
       version: '18.17.1'
     steps:
-      - test
+      - test:
+          run-in-band: true
 
   unit-electron28:
     executor:
       name: node
       version: '18.18.2'
     steps:
-      - test
+      - test:
+          run-in-band: true
 
   unit-electron29:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,9 +45,9 @@ commands:
 
   test:
     parameters:
-      run-in-band:
+      jest-parameters:
         type: boolean
-        default: false
+        default: --maxWorkers=2
     steps:
       - checkout
       - install
@@ -70,7 +70,7 @@ commands:
 
       - run:
           name: Jest
-          command: npm run test:unit:coverage -- --ci --maxWorkers=2 <<# parameters.run-in-band >>-i<</ parameters.run-in-band >> --reporters=default --reporters=jest-junit
+          command: npm run test:unit:coverage -- --ci --reporters=default --reporters=jest-junit << parameters.jest-parameters >>
           environment:
             JEST_JUNIT_OUTPUT_DIR: tmp/test-results
 
@@ -95,7 +95,7 @@ jobs:
       version: '18.17.1'
     steps:
       - test:
-          run-in-band: true
+          jest-parameters: -i
 
   unit-electron28:
     executor:
@@ -103,7 +103,7 @@ jobs:
       version: '18.18.2'
     steps:
       - test:
-          run-in-band: true
+          jest-parameters: -i
 
   unit-electron29:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,10 +44,6 @@ commands:
             - run: npm run check:audit
 
   test:
-    parameters:
-      jest-parameters:
-        type: string
-        default: --maxWorkers=2
     steps:
       - checkout
       - install
@@ -70,7 +66,7 @@ commands:
 
       - run:
           name: Jest
-          command: npm run test:unit:coverage -- --ci --reporters=default --reporters=jest-junit --detectOpenHandles << parameters.jest-parameters >>
+          command: npm run test:unit:coverage -- --ci --maxWorkers=2 --reporters=default --reporters=jest-junit
           environment:
             JEST_JUNIT_OUTPUT_DIR: tmp/test-results
 
@@ -94,16 +90,14 @@ jobs:
       name: node
       version: '18.17.1'
     steps:
-      - test:
-          jest-parameters: -i
+      - test
 
   unit-electron28:
     executor:
       name: node
       version: '18.18.2'
     steps:
-      - test:
-          jest-parameters: -i
+      - test
 
   unit-electron29:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ commands:
   test:
     parameters:
       jest-parameters:
-        type: boolean
+        type: string
         default: --maxWorkers=2
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ commands:
 
       - run:
           name: Jest
-          command: npm run test:unit:coverage -- --ci --reporters=default --reporters=jest-junit << parameters.jest-parameters >>
+          command: npm run test:unit:coverage -- --ci --reporters=default --reporters=jest-junit --detectOpenHandles << parameters.jest-parameters >>
           environment:
             JEST_JUNIT_OUTPUT_DIR: tmp/test-results
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,12 @@
 ### Added
 
 - `markdown.marp.html` setting to control rendering HTML within Marp Markdown ([#476](https://github.com/marp-team/marp-vscode/pull/476))
+- `markdown.marp.browser` and `markdown.marp.browserPath` settings to control internally using browser to export ([#478](https://github.com/marp-team/marp-vscode/pull/478))
 
 ### Deprecated
 
-- `markdown.marp.enableHtml` setting ([#476](https://github.com/marp-team/marp-vscode/pull/476))
+- Deprecated `markdown.marp.enableHtml` setting in favor of `markdown.marp.html` ([#476](https://github.com/marp-team/marp-vscode/pull/476))
+- Deprecated `markdown.marp.chromePath` setting in favor of `markdown.marp.browserPath` ([#478](https://github.com/marp-team/marp-vscode/pull/478))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,16 +14,18 @@
 
 - `markdown.marp.html` setting to control rendering HTML within Marp Markdown ([#476](https://github.com/marp-team/marp-vscode/pull/476))
 - `markdown.marp.browser` and `markdown.marp.browserPath` settings to control internally using browser to export ([#478](https://github.com/marp-team/marp-vscode/pull/478))
+- Support Firefox as a browser for exporting ([#473](https://github.com/marp-team/marp-vscode/pull/473), [#474](https://github.com/marp-team/marp-vscode/pull/474), [#478](https://github.com/marp-team/marp-vscode/pull/478))
+
+### Changed
+
+- Several allowed HTML elements through Marp Core are enabled by default ([#472](https://github.com/marp-team/marp-vscode/pull/472), [#474](https://github.com/marp-team/marp-vscode/pull/474), [#476](https://github.com/marp-team/marp-vscode/pull/476))
+- Upgrade development Node.js and dependent packages to the latest version ([#474](https://github.com/marp-team/marp-vscode/pull/474))
+- Migrate ESLint config to flat config ([#475](https://github.com/marp-team/marp-vscode/pull/475))
 
 ### Deprecated
 
 - Deprecated `markdown.marp.enableHtml` setting in favor of `markdown.marp.html` ([#476](https://github.com/marp-team/marp-vscode/pull/476))
 - Deprecated `markdown.marp.chromePath` setting in favor of `markdown.marp.browserPath` ([#478](https://github.com/marp-team/marp-vscode/pull/478))
-
-### Changed
-
-- Upgrade development Node.js and dependent packages to the latest version ([#474](https://github.com/marp-team/marp-vscode/pull/474))
-- Migrate ESLint config to flat config ([#475](https://github.com/marp-team/marp-vscode/pull/475))
 
 ## v2.8.0 - 2023-10-28
 

--- a/README.md
+++ b/README.md
@@ -128,9 +128,13 @@ You can also execute command from the Command Palette (<kbd>F1</kbd> or <kbd>Ctr
 - **PNG** (_First slide only)_
 - **JPEG** (_First slide only)_
 
-Default file type can choose by `markdown.marp.exportType` preference.
+Default file type can choose by the `markdown.marp.exportType` setting.
 
-> ⚠️ Export except HTML requires to install any one of [Google Chrome](https://www.google.com/chrome/), [Chromium](https://www.chromium.org/), or [Microsoft Edge](https://www.microsoft.com/edge). You may also specify the custom path for Chrome / Chromium-based browser by preference `markdown.marp.chromePath`.
+> [!IMPORTANT]
+> Exporting PDF, PPTX, and image formats requires to install any one of [Google Chrome](https://www.google.com/chrome/), [Chromium](https://www.chromium.org/), [Microsoft Edge](https://www.microsoft.com/edge), or [Firefox](https://www.mozilla.org/firefox/). You may control using browser and the custom path for the browser by `markdown.marp.browser` and `markdown.marp.browserPath` settings.
+
+> [!NOTE]
+> A legacy setting `markdown.marp.chromePath` is deprecated since v2. Please use `markdown.marp.browserPath` instead.
 
 ### Use custom theme CSS 🛡️
 
@@ -175,7 +179,7 @@ Markdown preview will reload updated theme CSS automatically when you edited the
 
 ### Outline extension
 
-When Marp Markdown is enabled, you can use the extended [outline view](https://code.visualstudio.com/docs/languages/markdown#_outline-view) like following. They are enabled by default but you may disable by `markdown.marp.outlineExtension` preference.
+When Marp Markdown is enabled, you can use the extended [outline view](https://code.visualstudio.com/docs/languages/markdown#_outline-view) like following. They are enabled by default but you may disable by the `markdown.marp.outlineExtension` setting.
 
 #### Outline view for each slide
 

--- a/package.json
+++ b/package.json
@@ -115,10 +115,27 @@
             "Use inherited setting from `#markdown.preview.breaks#`."
           ]
         },
-        "markdown.marp.chromePath": {
+        "markdown.marp.browser": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "chrome",
+            "edge",
+            "firefox"
+          ],
+          "default": "auto",
+          "description": "Controls the installed browser using internally to export PDF, PPTX, and the image.",
+          "enumDescriptions": [
+            "Automatically detect Chrome, Chromium, Edge, or Firefox.",
+            "Use Google Chrome.",
+            "Use Microsoft Edge.",
+            "Use Mozilla Firefox."
+          ]
+        },
+        "markdown.marp.browserPath": {
           "type": "string",
           "default": "",
-          "description": "Sets the custom path for Chrome or Chromium-based browser to export PDF, PPTX, and image. If it's empty, Marp will find out the installed Google Chrome / Chromium / Microsoft Edge."
+          "markdownDescription": "Configure the custom path for the installed browser using internally to export PDF, PPTX, and the image. The kind of browser is determined by `#markdown.marp.browser#`. When set to empty, Marp will find out a suitable installed browser automatically."
         },
         "markdown.marp.html": {
           "type": "string",
@@ -214,6 +231,12 @@
           "default": false,
           "description": "Enables all HTML elements in Marp Markdown. This setting is working only in the trusted workspace.",
           "deprecationMessage": "The setting \"markdown.marp.enableHtml\" is deprecated. Please use \"markdown.marp.html\" instead."
+        },
+        "markdown.marp.chromePath": {
+          "type": "string",
+          "default": "",
+          "description": "Sets the custom path for Chrome or Chromium-based browser to export PDF, PPTX, and image. If it's empty, Marp will find out the installed Google Chrome / Chromium / Microsoft Edge.",
+          "deprecationMessage": "The setting \"markdown.marp.chromePath\" is deprecated. Please use \"markdown.marp.browserPath\" instead."
         }
       }
     },

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -5,14 +5,18 @@ type MockedConf = Record<string, any>
 const defaultVSCodeVersion = 'v1.62.1'
 const defaultConf: MockedConf = {
   'markdown.marp.breaks': 'on',
-  'markdown.marp.chromePath': '',
-  'markdown.marp.enableHtml': false,
+  'markdown.marp.browser': 'auto',
+  'markdown.marp.browserPath': '',
   'markdown.marp.html': 'default',
   'markdown.marp.exportType': 'pdf',
   'markdown.marp.outlineExtension': true,
   'markdown.marp.pdf.noteAnnotations': false,
   'markdown.marp.pdf.outlines': 'off',
   'window.zoomLevel': 0,
+
+  // Legacy
+  'markdown.marp.chromePath': '',
+  'markdown.marp.enableHtml': false,
 }
 
 let currentConf: MockedConf = {}

--- a/src/commands/export.test.ts
+++ b/src/commands/export.test.ts
@@ -1,3 +1,4 @@
+import * as marpCliModule from '@marp-team/marp-cli'
 import { commands, env, window, workspace } from 'vscode'
 import * as marpCli from '../marp-cli'
 import * as option from '../option'
@@ -315,6 +316,66 @@ describe('#doExport', () => {
         expect.objectContaining({ pdfNotes: false }),
       )
     })
+  })
+
+  describe('when CLI was thrown CLIError with BROWSER_NOT_FOUND error code', () => {
+    it.each`
+      browser      | platform    | expected
+      ${'auto'}    | ${'win32'}  | ${['Google Chrome', 'Microsoft Edge', 'Firefox']}
+      ${'auto'}    | ${'darwin'} | ${['Google Chrome', 'Microsoft Edge', 'Firefox']}
+      ${'auto'}    | ${'linux'}  | ${['Google Chrome', 'Chromium', 'Microsoft Edge', 'Firefox']}
+      ${'chrome'}  | ${'win32'}  | ${['Google Chrome']}
+      ${'chrome'}  | ${'darwin'} | ${['Google Chrome']}
+      ${'chrome'}  | ${'linux'}  | ${['Google Chrome', 'Chromium']}
+      ${'edge'}    | ${'win32'}  | ${['Microsoft Edge']}
+      ${'edge'}    | ${'darwin'} | ${['Microsoft Edge']}
+      ${'edge'}    | ${'linux'}  | ${['Microsoft Edge']}
+      ${'firefox'} | ${'win32'}  | ${['Firefox']}
+      ${'firefox'} | ${'darwin'} | ${['Firefox']}
+      ${'firefox'} | ${'linux'}  | ${['Firefox']}
+    `(
+      'throws MarpCLIError with the message contains $expected to suggest browsers when running on $platform with browser option as $browser',
+      async ({ browser, platform, expected }) => {
+        expect.assertions(expected.length + 1)
+        setConfiguration({ 'markdown.marp.browser': browser })
+
+        const { platform: originalPlatform } = process
+
+        try {
+          Object.defineProperty(process, 'platform', { value: platform })
+
+          const consoleDebug = jest.spyOn(console, 'debug').mockImplementation()
+          const consoleInfo = jest.spyOn(console, 'info').mockImplementation()
+          const marpCliMock = jest
+            .spyOn(marpCliModule, 'marpCli')
+            .mockRejectedValue(
+              new marpCliModule.CLIError(
+                'mocked error',
+                marpCliModule.CLIErrorCode.NOT_FOUND_BROWSER,
+              ),
+            )
+
+          try {
+            await exportModule.doExport(saveURI(), document)
+            expect(window.showErrorMessage).toHaveBeenCalledTimes(1)
+
+            for (const fragment of expected) {
+              expect(window.showErrorMessage).toHaveBeenCalledWith(
+                expect.stringContaining(fragment),
+              )
+            }
+          } finally {
+            consoleDebug.mockRestore()
+            consoleInfo.mockRestore()
+            marpCliMock.mockRestore()
+          }
+        } finally {
+          Object.defineProperty(process, 'platform', {
+            value: originalPlatform,
+          })
+        }
+      },
+    )
   })
 
   describe('when the save path has non-file scheme', () => {

--- a/src/commands/export.test.ts
+++ b/src/commands/export.test.ts
@@ -344,16 +344,17 @@ describe('#doExport', () => {
         try {
           Object.defineProperty(process, 'platform', { value: platform })
 
-          const consoleDebug = jest.spyOn(console, 'debug').mockImplementation()
-          const consoleInfo = jest.spyOn(console, 'info').mockImplementation()
-          const marpCliMock = jest
-            .spyOn(marpCliModule, 'marpCli')
-            .mockRejectedValue(
-              new marpCliModule.CLIError(
-                'mocked error',
-                marpCliModule.CLIErrorCode.NOT_FOUND_BROWSER,
-              ),
-            )
+          const runMarpCLI = jest
+            .spyOn(marpCli, 'default')
+            .mockImplementation(async (_, __, opts) => {
+              opts?.onCLIError?.({
+                error: new marpCliModule.CLIError(
+                  'mocked error',
+                  marpCliModule.CLIErrorCode.NOT_FOUND_BROWSER,
+                ),
+                codes: marpCliModule.CLIErrorCode,
+              })
+            })
 
           try {
             await exportModule.doExport(saveURI(), document)
@@ -365,9 +366,7 @@ describe('#doExport', () => {
               )
             }
           } finally {
-            consoleDebug.mockRestore()
-            consoleInfo.mockRestore()
-            marpCliMock.mockRestore()
+            runMarpCLI.mockRestore()
           }
         } finally {
           Object.defineProperty(process, 'platform', {

--- a/src/marp-cli.test.ts
+++ b/src/marp-cli.test.ts
@@ -27,7 +27,7 @@ describe('Marp CLI integration', () => {
   })
 
   it('runs Marp CLI with passed args', async () => {
-    const marpCliSpy = jest.spyOn(marpCliModule, 'marpCli')
+    const marpCliSpy = jest.spyOn(marpCliModule, 'marpCli').mockResolvedValue(0)
     await runMarpCli(['--version'])
 
     expect(marpCliSpy).toHaveBeenCalledWith(['--version'], undefined)

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -88,21 +88,17 @@ export default async function runMarpCli(
   const { marpCli, CLIError, CLIErrorCode } = await import(
     '@marp-team/marp-cli'
   )
-  const { CHROME_PATH } = process.env
 
   let exitCode: number
 
   try {
-    process.env.CHROME_PATH =
-      marpConfiguration().get<string>('chromePath') || CHROME_PATH
-
     exitCode = await marpCli(argv, opts)
   } catch (e) {
     console.error(e)
 
     if (
       e instanceof CLIError &&
-      e.errorCode === CLIErrorCode.NOT_FOUND_CHROMIUM
+      e.errorCode === CLIErrorCode.NOT_FOUND_BROWSER
     ) {
       const browsers = ['[Google Chrome](https://www.google.com/chrome/)']
 
@@ -119,8 +115,6 @@ export default async function runMarpCli(
     }
 
     throw e
-  } finally {
-    process.env.CHROME_PATH = CHROME_PATH
   }
 
   if (exitCode !== 0) {

--- a/src/option.test.ts
+++ b/src/option.test.ts
@@ -1,5 +1,5 @@
 import * as nodeFetch from 'node-fetch'
-import { Uri, workspace } from 'vscode'
+import { Uri, window, workspace } from 'vscode'
 import * as option from './option'
 import { textEncoder } from './utils'
 
@@ -108,6 +108,62 @@ describe('Option', () => {
         pages: true,
         headings: true,
       })
+    })
+
+    it('sets correct browser option and browser path option', async () => {
+      setConfiguration({
+        'markdown.marp.browser': 'chrome',
+        'markdown.marp.browserPath': '',
+      })
+      expect(await subject({ uri: untitledUri })).toStrictEqual(
+        expect.objectContaining({
+          browser: 'chrome',
+          browserPath: undefined,
+        }),
+      )
+
+      // With browser path
+      setConfiguration({
+        'markdown.marp.browser': 'auto',
+        'markdown.marp.browserPath': '/path/to/browser',
+      })
+      expect(await subject({ uri: untitledUri })).toStrictEqual(
+        expect.objectContaining({
+          browser: 'auto',
+          browserPath: '/path/to/browser',
+        }),
+      )
+
+      // Firefox browser auto detection
+      setConfiguration({
+        'markdown.marp.browser': 'auto',
+        'markdown.marp.browserPath': '/path/to/firefox',
+      })
+      expect(await subject({ uri: untitledUri })).toStrictEqual(
+        expect.objectContaining({
+          browser: 'firefox',
+          browserPath: '/path/to/firefox',
+        }),
+      )
+
+      // [Legacy] markdown.marp.chromePath
+      setConfiguration({
+        'markdown.marp.browser': 'auto',
+        'markdown.marp.browserPath': '',
+        'markdown.marp.chromePath': '/path/to/browser',
+      })
+      expect(await subject({ uri: untitledUri })).toStrictEqual(
+        expect.objectContaining({
+          browser: 'chrome',
+          browserPath: '/path/to/browser',
+        }),
+      )
+      expect(window.showWarningMessage).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'The setting "markdown.marp.chromePath" is deprecated',
+        ),
+        expect.anything(),
+      )
     })
 
     describe('when targeted document belongs to workspace', () => {


### PR DESCRIPTION
Marp CLI v4 has been supported Firefox browser. To support Firefox browser in the next major version of Marp for VS Code, this PR adds `markdown.marp.browser` and `markdown.marp.browserPath` settings.

### `markdown.marp.browser`

This option is coressponding to [`browser` option of Marp CLI](https://github.com/marp-team/marp-cli#choose-browser---browser).

- `auto`: Automatically detect Chrome, Chromium, Edge, or Firefox.
- `chrome`: Use Google Chrome.
- `edge`: Use Microsoft Edge.
- `firefox`: Use Mozilla Firefox.

### `markdown.marp.browserPath`

This option is to replace a legacy setting `markdown.marp.chromePath`. Set the custom browser path to export.

The kind of browser is specified by `markdown.marp.browser`. If it was `auto`, Marp for VS Code will detect the kind of browser automatically. Currently we simply detect if the binary name is including `firefox` or `fx`. 