### PR TITLE
Mark `markdown.marp.strictPathResolutionDuringExport` with "Experimental" UI label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Apply theme color to Marp icon ([#479](https://github.com/marp-team/marp-vscode/issues/479), [#484](https://github.com/marp-team/marp-vscode/pull/484))
+- Mark `markdown.marp.strictPathResolutionDuringExport` with "Experimental" UI label ([#485](https://github.com/marp-team/marp-vscode/pull/485))
 
 ## v3.0.0 - 2024-12-31
 

--- a/package.json
+++ b/package.json
@@ -213,7 +213,10 @@
         "markdown.marp.strictPathResolutionDuringExport": {
           "type": "boolean",
           "default": false,
-          "markdownDescription": "_[Experimental]_ Enables strict path resolution during export. If enabled, the export command tries to resolve relative paths from VS Code workspace that a Markdown file belongs. If disabled, or the Markdown does not belong to any workspace, the export command resolves paths based on the local file system."
+          "description": "Enables strict path resolution during export. If enabled, the export command tries to resolve relative paths from VS Code workspace that a Markdown file belongs. If disabled, or the Markdown does not belong to any workspace, the export command resolves paths based on the local file system.",
+          "tags": [
+            "experimental"
+          ]
         },
         "markdown.marp.themes": {
           "type": "array",


### PR DESCRIPTION
Improve `markdown.marp.strictPathResolutionDuringExport` setting in GUI to show with `experimental` UI label.

![](https://github.com/user-attachments/assets/15fbcd0a-4b5f-4b0d-b88f-fa50aa8f9605)
