### PR TITLE
Fix the encoding in the export output when Markdown file has been saved with non UTF-8 encoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/jest": "^29.5.14",
         "@types/lodash.debounce": "^4.0.9",
         "@types/markdown-it": "^14.1.2",
-        "@types/vscode": "~1.86.0",
+        "@types/vscode": "~1.98.0",
         "@vscode/test-web": "^0.0.67",
         "@vscode/vsce": "^3.2.2",
         "abort-controller": "^3.0.0",
@@ -69,7 +69,7 @@
         "yaml": "^2.7.0"
       },
       "engines": {
-        "vscode": "^1.86.0"
+        "vscode": "^1.98.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4428,9 +4428,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.86.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.86.0.tgz",
-      "integrity": "sha512-DnIXf2ftWv+9LWOB5OJeIeaLigLHF7fdXF6atfc7X5g2w/wVZBgk0amP7b+ub5xAuW1q7qP5YcFvOcit/DtyCQ==",
+      "version": "1.98.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.98.0.tgz",
+      "integrity": "sha512-+KuiWhpbKBaG2egF+51KjbGWatTH5BbmWQjSLMDCssb4xF8FJnW4nGH4nuAdOOfMbpD0QlHtI+C3tPq+DoKElg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -33,8 +33,11 @@
     "url": "https://github.com/marp-team/marp-vscode"
   },
   "engines": {
-    "vscode": "^1.86.0"
+    "vscode": "^1.98.0"
   },
+  "enabledApiProposals": [
+    "textDocumentEncoding"
+  ],
   "main": "./lib/extension.js",
   "browser": "./dist/extension.js",
   "icon": "images/icon.png",
@@ -352,7 +355,7 @@
     "@types/jest": "^29.5.14",
     "@types/lodash.debounce": "^4.0.9",
     "@types/markdown-it": "^14.1.2",
-    "@types/vscode": "~1.86.0",
+    "@types/vscode": "~1.98.0",
     "@vscode/test-web": "^0.0.67",
     "@vscode/vsce": "^3.2.2",
     "abort-controller": "^3.0.0",

--- a/src/marp-cli.ts
+++ b/src/marp-cli.ts
@@ -27,7 +27,11 @@ export interface MarpCLIErrorHandler {
 
 export async function createWorkFile(doc: TextDocument): Promise<WorkFile> {
   // Use a real file if posibble
-  if (doc.uri.scheme === 'file' && !doc.isDirty) {
+  if (
+    doc.uri.scheme === 'file' &&
+    !doc.isDirty &&
+    (doc.encoding === 'utf8' || doc.encoding === 'utf8bom')
+  ) {
     return { path: doc.uri.fsPath, cleanup: () => Promise.resolve() }
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
     "strict": true,
     "target": "es6"
   },
-  "include": ["src"]
+  "include": ["src", "vscode.proposed.textDocumentEncoding.d.ts"]
 }

--- a/vscode.proposed.textDocumentEncoding.d.ts
+++ b/vscode.proposed.textDocumentEncoding.d.ts
@@ -1,0 +1,170 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+	// https://github.com/microsoft/vscode/issues/241449
+
+	export interface TextDocument {
+
+		/**
+		 * The file encoding of this document that will be used when the document is saved.
+		 *
+		 * Use the {@link workspace.onDidChangeTextDocument onDidChangeTextDocument}-event to
+		 * get notified when the document encoding changes.
+		 *
+		 * Note that the possible encoding values are currently defined as any of the following:
+		 * 'utf8', 'utf8bom', 'utf16le', 'utf16be', 'windows1252', 'iso88591', 'iso88593',
+		 * 'iso885915', 'macroman', 'cp437', 'windows1256', 'iso88596', 'windows1257',
+		 * 'iso88594', 'iso885914', 'windows1250', 'iso88592', 'cp852', 'windows1251',
+		 * 'cp866', 'cp1125', 'iso88595', 'koi8r', 'koi8u', 'iso885913', 'windows1253',
+		 * 'iso88597', 'windows1255', 'iso88598', 'iso885910', 'iso885916', 'windows1254',
+		 * 'iso88599', 'windows1258', 'gbk', 'gb18030', 'cp950', 'big5hkscs', 'shiftjis',
+		 * 'eucjp', 'euckr', 'windows874', 'iso885911', 'koi8ru', 'koi8t', 'gb2312',
+		 * 'cp865', 'cp850'.
+		 */
+		readonly encoding: string;
+	}
+
+	export namespace workspace {
+
+		/**
+		 * Opens a document. Will return early if this document is already open. Otherwise
+		 * the document is loaded and the {@link workspace.onDidOpenTextDocument didOpen}-event fires.
+		 *
+		 * The document is denoted by an {@link Uri}. Depending on the {@link Uri.scheme scheme} the
+		 * following rules apply:
+		 * * `file`-scheme: Open a file on disk (`openTextDocument(Uri.file(path))`). Will be rejected if the file
+		 * does not exist or cannot be loaded.
+		 * * `untitled`-scheme: Open a blank untitled file with associated path (`openTextDocument(Uri.file(path).with({ scheme: 'untitled' }))`).
+		 * The language will be derived from the file name.
+		 * * For all other schemes contributed {@link TextDocumentContentProvider text document content providers} and
+		 * {@link FileSystemProvider file system providers} are consulted.
+		 *
+		 * *Note* that the lifecycle of the returned document is owned by the editor and not by the extension. That means an
+		 * {@linkcode workspace.onDidCloseTextDocument onDidClose}-event can occur at any time after opening it.
+		 *
+		 * @throws This method will throw an error when an existing text document with the provided uri is dirty.
+		 *
+		 * @param uri Identifies the resource to open.
+		 * @param options Options to control how the document will be opened.
+		 * @returns A promise that resolves to a {@link TextDocument document}.
+		 */
+		export function openTextDocument(uri: Uri, options?: {
+			/**
+			 * The {@link TextDocument.encoding encoding} of the document to use
+			 * for decoding the underlying buffer to text. If omitted, the encoding
+			 * will be guessed based on the file content and/or the editor settings
+			 * unless the document is already opened.
+			 *
+			 * See {@link TextDocument.encoding} for more information about valid
+			 * values for encoding.
+			 *
+			 * *Note* that opening a text document that was already opened with a
+			 * different encoding has the potential of changing the text contents of
+			 * the text document. Specifically, when the encoding results in a
+			 * different set of characters than the previous encoding.
+			 *
+			 * *Note* that if you open a document with an encoding that does not
+			 * support decoding the underlying bytes, content may be replaced with
+			 * substitution characters as appropriate.
+			 */
+			encoding?: string;
+		}): Thenable<TextDocument>;
+
+		/**
+		 * A short-hand for `openTextDocument(Uri.file(path))`.
+		 *
+		 * @see {@link workspace.openTextDocument}
+		 * @param path A path of a file on disk.
+		 * @param options Options to control how the document will be opened.
+		 * @returns A promise that resolves to a {@link TextDocument document}.
+		 */
+		export function openTextDocument(path: string, options?: {
+			/**
+			 * The {@link TextDocument.encoding encoding} of the document to use
+			 * for decoding the underlying buffer to text. If omitted, the encoding
+			 * will be guessed based on the file content and/or the editor settings
+			 * unless the document is already opened.
+			 *
+			 * See {@link TextDocument.encoding} for more information about valid
+			 * values for encoding.
+			 *
+			 * *Note* that opening a text document that was already opened with a
+			 * different encoding has the potential of changing the text contents of
+			 * the text document. Specifically, when the encoding results in a
+			 * different set of characters than the previous encoding.
+			 *
+			 * *Note* that if you open a document with an encoding that does not
+			 * support decoding the underlying bytes, content may be replaced with
+			 * substitution characters as appropriate.
+			 */
+			encoding?: string;
+		}): Thenable<TextDocument>;
+
+		/**
+		 * Opens an untitled text document. The editor will prompt the user for a file
+		 * path when the document is to be saved. The `options` parameter allows to
+		 * specify the *language*, *encoding* and/or the *content* of the document.
+		 *
+		 * @param options Options to control how the document will be created.
+		 * @returns A promise that resolves to a {@link TextDocument document}.
+		 */
+		export function openTextDocument(options?: {
+			/**
+			 * The {@link TextDocument.languageId language} of the document.
+			 */
+			language?: string;
+			/**
+			 * The initial contents of the document.
+			 */
+			content?: string;
+			/**
+			 * The {@link TextDocument.encoding encoding} of the document.
+			 */
+			encoding?: string;
+		}): Thenable<TextDocument>;
+
+		/**
+		 * Decodes the content from a `Uint8Array` to a `string`. You MUST
+		 * provide the entire content at once to ensure that the encoding
+		 * can properly apply. Do not use this method to decode content
+		 * in chunks, as that may lead to incorrect results.
+		 *
+		 * If no encoding is provided, will try to pick an encoding based
+		 * on user settings and the content of the buffer (for example
+		 * byte order marks).
+		 *
+		 * *Note* that if you decode content that is unsupported by the
+		 * encoding, the result may contain substitution characters as
+		 * appropriate.
+		 *
+		 * @throws This method will throw an error when the content is binary.
+		 *
+		 * @param content The content to decode as a `Uint8Array`.
+		 * @param uri The URI that represents the file. This information
+		 * is used to figure out the encoding related configuration for the file.
+		 * @param options Allows to explicitly pick the encoding to use. See {@link TextDocument.encoding}
+		 * for more information about valid values for encoding.
+		 * @returns A thenable that resolves to the decoded `string`.
+		 */
+		export function decode(content: Uint8Array, uri: Uri | undefined, options?: { encoding: string }): Thenable<string>;
+
+		/**
+		 * Encodes the content of a `string` to a `Uint8Array`.
+		 *
+		 * If no encoding is provided, will try to pick an encoding based
+		 * on user settings.
+		 *
+		 * @param content The content to decode as a `string`.
+		 * @param uri The URI that represents the file. This information
+		 * is used to figure out the encoding related configuration for the file.
+		 * @param options Allows to explicitly pick the encoding to use. See {@link TextDocument.encoding}
+		 * for more information about valid values for encoding.
+		 * @returns A thenable that resolves to the encoded `Uint8Array`.
+		 */
+		export function encode(content: string, uri: Uri | undefined, options?: { encoding: string }): Thenable<Uint8Array>;
+	}
+}


### PR DESCRIPTION
> [!WARNING]
> This PR is using [the proposal VS Code API](https://code.visualstudio.com/api/advanced-topics/using-proposed-api) in v1.98. The extension depending on proposal API cannot publish to the marketplace, so this PR is currently available only for testing.

Fix #497 (marp-team/marp#558).