### PR TITLE
Highlight the slide on current cursor if `markdown.preview.markEditorSelection` is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Highlight the slide based on the cursor position if `markdown.preview.markEditorSelection` is enabled ([#504](https://github.com/marp-team/marp-vscode/issues/504), [#506](https://github.com/marp-team/marp-vscode/pull/506))
+
 ## v3.1.1 - 2025-03-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ You can create a new Marp Markdown document from **"New File..."** menu (<kbd>Al
 
 While enabled Marp features by `marp: true`, Marp for VS Code can preview your Marp Markdown with the same way as [a built-in Markdown preview](https://code.visualstudio.com/docs/languages/markdown#_markdown-preview).
 
-If you are not familiar with editing Markdown on VS Code, we recommend to learn what you can do in [VS Code documentation](https://code.visualstudio.com/docs/languages/markdown) at first.
+In the preview, an active slide is highlighted based on the current position of the editor, as like as the regular Markdown preview. To disable this highlight, you can set `markdown.preview.markEditorSelection` setting to `false`.
+
+> [!NOTE]
+> If you are not familiar with editing Markdown on VS Code, we recommend to learn what you can do in [VS Code documentation](https://code.visualstudio.com/docs/languages/markdown) at first.
 
 ### IntelliSense for Marp directives
 

--- a/marp-vscode.css
+++ b/marp-vscode.css
@@ -27,10 +27,31 @@ body.marp-vscode blockquote {
 @media screen {
   body.marp-vscode {
     overflow-y: scroll;
+
+    /* stylelint-disable-next-line selector-class-pattern */
+    &.showEditorSelection {
+      --marp-vscode-highlight-color: rgb(255 255 255 / 40%);
+
+      &.vscode-light {
+        --marp-vscode-highlight-color: rgb(0 0 0 / 15%);
+      }
+    }
   }
 
   #__marp-vscode [data-marp-vscode-slide-wrapper] {
     margin: 20px;
+    position: relative;
+
+    &.code-active-line,
+    &:has(.code-active-line) {
+      &::before {
+        position: absolute;
+        content: '';
+        inset: -7px;
+        border: 3px solid var(--marp-vscode-highlight-color, transparent);
+        pointer-events: none;
+      }
+    }
   }
 
   #__marp-vscode svg[data-marpit-svg] {

--- a/marp-vscode.css
+++ b/marp-vscode.css
@@ -35,6 +35,10 @@ body.marp-vscode blockquote {
       &.vscode-light {
         --marp-vscode-highlight-color: rgb(0 0 0 / 15%);
       }
+
+      &.vscode-high-contrast {
+        --marp-vscode-highlight-color: rgb(255 160 0 / 70%);
+      }
     }
   }
 


### PR DESCRIPTION
Resolves #504.

This PR updates a style for Marp preview to highlight the slide based on current cursor in Markdown. This behavior will match to VS Code's preview.

|VS Code's Markdown preview|Marp preview|
|:---:|:---:|
|![preview-vscode](https://github.com/user-attachments/assets/db034197-b900-452c-9fed-1f86707d2d79)|![preview-marp](https://github.com/user-attachments/assets/48176b5e-75af-4742-92ed-3b1e8dca4af3)|

User can disable the highlight ring by changing `markdown.preview.markEditorSelection` setting to `false`.
