### PR TITLE
Refactor normalizePaths method to allow absolute paths in Theme settings and prevent duplicates

### DIFF
--- a/src/themes.test.ts
+++ b/src/themes.test.ts
@@ -1,4 +1,3 @@
-import path from 'node:path'
 import { Uri } from 'vscode'
 import { Themes } from './themes'
 
@@ -17,7 +16,10 @@ describe('Themes', () => {
     })
 
     it('adds remote URLs', () => {
-      const paths = ['https://example.com/theme.css', 'http://example.com/theme2.css']
+      const paths = [
+        'https://example.com/theme.css',
+        'http://example.com/theme2.css',
+      ]
       const normalized = normalizePaths(paths)
       expect(normalized).toHaveLength(2)
       expect(normalized[0].toString()).toBe('https://example.com/theme.css')
@@ -60,10 +62,10 @@ describe('Themes', () => {
         'https://example.com/theme.css',
         '/absolute/path/theme.css',
         'relative/theme.css',
-        'https://example.com/theme.css',      // Duplicate
-        '/absolute/path/theme.css',           // Duplicate
-        'relative/theme.css',                 // Duplicate
-        '/root/workspace/relative/theme.css'  // Duplicate absolute of relative path
+        'https://example.com/theme.css', // Duplicate
+        '/absolute/path/theme.css', // Duplicate
+        'relative/theme.css', // Duplicate
+        '/root/workspace/relative/theme.css', // Duplicate absolute of relative path
       ]
 
       const normalized = normalizePaths(paths, rootUri)

--- a/src/themes.test.ts
+++ b/src/themes.test.ts
@@ -1,0 +1,76 @@
+import path from 'node:path'
+import { Uri } from 'vscode'
+import { Themes } from './themes'
+
+describe('Themes', () => {
+  describe('normalizePaths', () => {
+    const themes = new Themes()
+    const normalizePaths = (paths: string[], rootUri?: Uri) =>
+      (themes as any).normalizePaths(paths, rootUri)
+
+    it('returns an empty array if paths is empty', () => {
+      expect(normalizePaths([])).toEqual([])
+    })
+
+    it('ignores non-string paths', () => {
+      expect(normalizePaths([123 as any, null as any])).toEqual([])
+    })
+
+    it('adds remote URLs', () => {
+      const paths = ['https://example.com/theme.css', 'http://example.com/theme2.css']
+      const normalized = normalizePaths(paths)
+      expect(normalized).toHaveLength(2)
+      expect(normalized[0].toString()).toBe('https://example.com/theme.css')
+      expect(normalized[1].toString()).toBe('http://example.com/theme2.css')
+    })
+
+    it('adds absolute file paths', () => {
+      const posixPath = '/absolute/path/to/theme.css'
+
+      const normalizedPosix = normalizePaths([posixPath])
+      expect(normalizedPosix).toHaveLength(1)
+      expect(normalizedPosix[0].scheme).toBe('file')
+      expect(normalizedPosix[0].path).toBe('/absolute/path/to/theme.css')
+
+      const winPath = 'C:\\absolute\\path\\to\\theme.css'
+      const normalizedWin = normalizePaths([winPath])
+      expect(normalizedWin).toHaveLength(1)
+      expect(normalizedWin[0].scheme).toBe('file')
+    })
+
+    it('adds relative paths resolved against rootUri', () => {
+      const rootUri = Uri.file('/root/workspace')
+      const normalized = normalizePaths(['relative/theme.css'], rootUri)
+
+      expect(normalized).toHaveLength(1)
+      expect(normalized[0].scheme).toBe('file')
+      expect(normalized[0].path).toBe('/root/workspace/relative/theme.css')
+    })
+
+    it('prevents directory traversal attacks for relative paths', () => {
+      const rootUri = Uri.file('/root/workspace')
+
+      const normalized = normalizePaths(['../external/theme.css'], rootUri)
+      expect(normalized).toHaveLength(0)
+    })
+
+    it('removes duplicate paths', () => {
+      const rootUri = Uri.file('/root/workspace')
+      const paths = [
+        'https://example.com/theme.css',
+        '/absolute/path/theme.css',
+        'relative/theme.css',
+        'https://example.com/theme.css',      // Duplicate
+        '/absolute/path/theme.css',           // Duplicate
+        'relative/theme.css',                 // Duplicate
+        '/root/workspace/relative/theme.css'  // Duplicate absolute of relative path
+      ]
+
+      const normalized = normalizePaths(paths, rootUri)
+      expect(normalized).toHaveLength(3)
+      expect(normalized[0].toString()).toBe('https://example.com/theme.css')
+      expect(normalized[1].path).toBe('/absolute/path/theme.css')
+      expect(normalized[2].path).toBe('/root/workspace/relative/theme.css')
+    })
+  })
+})

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -178,9 +178,9 @@ export class Themes {
     const watcherPattern: GlobPattern | undefined =
       type !== ThemeType.Remote
         ? new RelativePattern(
-          Uri.joinPath(themeUri, '..'),
-          themeUri.path.split('/').pop()!,
-        )
+            Uri.joinPath(themeUri, '..'),
+            themeUri.path.split('/').pop()!,
+          )
         : undefined
 
     if (watcherPattern) {

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import Marp from '@marp-team/marp-core'
 import {
   commands,
@@ -120,36 +121,29 @@ export class Themes {
   }
 
   private normalizePaths(paths: string[], rootUri: Uri | undefined): Uri[] {
-    const normalizedPaths = new Set<Uri>()
+    const seen = new Map<string, Uri>()
+
+    const add = (uri: Uri) => {
+      const key = uri.toString()
+      if (!seen.has(key)) seen.set(key, uri)
+    }
 
     for (const p of paths) {
       if (typeof p !== 'string') continue
 
       if (isRemotePath(p)) {
-        normalizedPaths.add(Uri.parse(p, true))
+        add(Uri.parse(p, true))
+      } else if (path.posix.isAbsolute(p) || path.win32.isAbsolute(p)) {
+        add(Uri.file(p))
       } else if (rootUri) {
         const targetUri = Uri.joinPath(rootUri, p)
 
         // Prevent directory traversal
-        if (targetUri.path.startsWith(rootUri.path)) {
-          normalizedPaths.add(targetUri)
-        }
+        if (targetUri.path.startsWith(rootUri.path)) add(targetUri)
       }
     }
 
-    const out: Uri[] = []
-    const outStringPaths: string[] = []
-
-    for (const uri of normalizedPaths) {
-      const uriString = uri.toString()
-
-      if (!outStringPaths.includes(uriString)) {
-        out.push(uri)
-        outStringPaths.push(uriString)
-      }
-    }
-
-    return out
+    return [...seen.values()]
   }
 
   private async registerTheme(themeUri: Uri): Promise<Theme> {
@@ -184,9 +178,9 @@ export class Themes {
     const watcherPattern: GlobPattern | undefined =
       type !== ThemeType.Remote
         ? new RelativePattern(
-            Uri.joinPath(themeUri, '..'),
-            themeUri.path.split('/').pop()!,
-          )
+          Uri.joinPath(themeUri, '..'),
+          themeUri.path.split('/').pop()!,
+        )
         : undefined
 
     if (watcherPattern) {


### PR DESCRIPTION
**Path normalization enhancements:**

* Use standard Node.js `path` module in `src/themes.ts` to support cross-platform path handling.
* Handle absolute paths using `path.posix.isAbsolute` and `path.win32.isAbsolute`.
* Refactored `normalizePaths` in `src/themes.ts` to use a `Map` for deduplication based on the absolute URI string.
* Ensured that relative paths are resolved against `rootUri` and that directory traversal outside the root is prevented.
* Added a new test suite in `src/themes.test.ts` to thoroughly test the `normalizePaths` method, covering empty input, non-string values, remote URLs, absolute and relative paths, directory traversal prevention, and duplicate removal.

