### PR TITLE
Add an experimental `markdown.marp.openExportedHtmlInIntegratedBrowser` setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Experimental `markdown.marp.openExportedHtmlInIntegratedBrowser` setting to open exported HTML in VS Code's integrated browser ([#555](https://github.com/marp-team/marp-vscode/pull/555))
+
 ## v3.4.1 - 2026-03-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Use [VS Code integrated browser](https://code.visualstudio.com/docs/debugtest/in
 
 Key features provided by the [Marp CLI `bespoke` template](https://github.com/marp-team/marp-cli#bespoke-template-default), such as [fragmented list](https://marpit.marp.app/fragmented-list) support, presenter view, and [transitions](https://github.com/marp-team/marp-cli/blob/main/docs/bespoke-transitions/README.md), also work in the VS Code integrated browser.
 
-The only exception is full-screen toggle: VS Code denies a permission for the full-screen view.
+The only exception is full-screen toggle: VS Code denies a permission for the full-screen view. Therefore, _if you are giving a presentation using the entire monitor, you should turn off this setting to use a browser._
 
 ### [`markdown.marp.pptx.editable`](https://github.com/marp-team/marp-vscode/pull/489)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI](https://img.shields.io/circleci/project/github/marp-team/marp-vscode/main.svg?style=flat-square&logo=circleci)](https://circleci.com/gh/marp-team/marp-vscode/)
 [![Codecov](https://img.shields.io/codecov/c/github/marp-team/marp-vscode/main.svg?style=flat-square&logo=codecov)](https://codecov.io/gh/marp-team/marp-vscode)
-[![Visual Studio Marketplace](https://img.shields.io/visual-studio-marketplace/v/marp-team.marp-vscode.svg?style=flat-square&logo=visual-studio-code&label=VS%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=marp-team.marp-vscode)
+[![Visual Studio Marketplace](https://img.shields.io/github/v/release/marp-team/marp-vscode.svg?style=flat-square&label=VS%20Marketplace)](https://marketplace.visualstudio.com/items?itemName=marp-team.marp-vscode)
 [![Open VSX](https://img.shields.io/open-vsx/v/marp-team/marp-vscode?label=Open%20VSX&style=flat-square)](https://open-vsx.org/extension/marp-team/marp-vscode)
 [![LICENSE](https://img.shields.io/github/license/marp-team/marp-vscode.svg?style=flat-square)](./LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -254,6 +254,18 @@ Enables a diagnostic that warns when slide content overflows the safe area defin
 
 It is helpful for identifying some potential presentation issues, such as cropped content, excessive content on a single page, and an unnatural layouts.
 
+### [`markdown.marp.openExportedHtmlInIntegratedBrowser`](https://github.com/marp-team/marp-vscode/pull/555)
+
+Use [VS Code integrated browser](https://code.visualstudio.com/docs/debugtest/integrated-browser) to open the exported HTML file when `markdown.marp.exportAutoOpen` setting is enabled. It requires VS Code v1.109 and later. This allows users to play presentations in VS Code tabs or external windows.
+
+- `off`: The exported HTML will open in the external browser app.
+- `tab`: The exported HTML will open in VS Code integrated browser as a new tab.
+- `window`: The exported HTML will open in VS Code integrated browser as a new window.
+
+Key features provided by the [Marp CLI `bespoke` template](https://github.com/marp-team/marp-cli#bespoke-template-default), such as [fragmented list](https://marpit.marp.app/fragmented-list) support, presenter view, and [transitions](https://github.com/marp-team/marp-cli/blob/main/docs/bespoke-transitions/README.md), also work in the VS Code integrated browser.
+
+The only exception is full-screen toggle: VS Code denies a permission for the full-screen view.
+
 ### [`markdown.marp.pptx.editable`](https://github.com/marp-team/marp-vscode/pull/489)
 
 You can enable the experimental feature to export PPTX with editable contents, based on [Marp CLI's corresponding experimental option](https://github.com/marp-team/marp-cli#experimental-generate-editable-pptx---pptx-editable). This feature requires to install both of the compatible browser and [LibreOffice Impress](https://www.libreoffice.org/).

--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
             "window"
           ],
           "default": "off",
-          "markdownDescription": "Use [VS Code's integrated browser](https://code.visualstudio.com/docs/debugtest/integrated-browser) to open the exported HTML file when `#markdown.marp.exportAutoOpen#` is enabled. Please note that the full-screen view is restricted by the integrated browser.",
+          "markdownDescription": "Use [VS Code's integrated browser](https://code.visualstudio.com/docs/debugtest/integrated-browser) to open the exported HTML file when `#markdown.marp.exportAutoOpen#` is enabled. Please note that it requires VS Code v1.109+, and the full-screen view is restricted by the integrated browser.",
           "enumDescriptions": [
             "Use the default browser installed on your OS.",
             "Open in the integrated browser as a new tab.",

--- a/package.json
+++ b/package.json
@@ -206,7 +206,7 @@
             "window"
           ],
           "default": "off",
-          "markdownDescription": "Use [VS Code's integrated browser](https://code.visualstudio.com/docs/debugtest/integrated-browser) to open the exported HTML file when `#markdown.marp.exportAutoOpen#` is enabled. Please note that it requires VS Code v1.109+, and the full-screen view is restricted by the integrated browser.",
+          "markdownDescription": "Use [VS Code integrated browser](https://code.visualstudio.com/docs/debugtest/integrated-browser) to open the exported HTML file when `#markdown.marp.exportAutoOpen#` is enabled. Please note that it requires VS Code v1.109+, and the full-screen view is restricted by the integrated browser.",
           "enumDescriptions": [
             "Use the default browser installed on your OS.",
             "Open in the integrated browser as a new tab.",

--- a/package.json
+++ b/package.json
@@ -198,6 +198,24 @@
             "Use KaTeX (https://katex.org/)."
           ]
         },
+        "markdown.marp.openExportedHtmlInIntegratedBrowser": {
+          "type": "string",
+          "enum": [
+            "off",
+            "tab",
+            "window"
+          ],
+          "default": "off",
+          "markdownDescription": "Use [VS Code's integrated browser](https://code.visualstudio.com/docs/debugtest/integrated-browser) to open the exported HTML file when `#markdown.marp.exportAutoOpen#` is enabled. Please note that the full-screen view is restricted by the integrated browser.",
+          "enumDescriptions": [
+            "Use the default browser installed on your OS.",
+            "Open in the integrated browser as a new tab.",
+            "Open in the integrated browser as a new window."
+          ],
+          "tags": [
+            "experimental"
+          ]
+        },
         "markdown.marp.outlineExtension": {
           "type": "boolean",
           "default": true,

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -146,6 +146,7 @@ export const commands = {
   executeCommand: jest.fn(async () => {
     // no ops
   }),
+  getCommands: jest.fn(async () => ['workbench.action.browser.open']),
   registerCommand: jest.fn(),
 }
 

--- a/src/commands/export.test.ts
+++ b/src/commands/export.test.ts
@@ -191,6 +191,55 @@ describe('#saveDialog', () => {
       expect(env.openExternal).toHaveBeenCalledWith(saveURI)
     })
 
+    it('opens in integrated browser tab when doExport() returns autoOpen config for tab', async () => {
+      exportResult.autoOpen = { integratedBrowser: 'tab' }
+
+      await exportModule.saveDialog(document)
+
+      expect(window.showInformationMessage).not.toHaveBeenCalled()
+      expect(commands.getCommands).toHaveBeenCalledWith(true)
+      expect(commands.executeCommand).toHaveBeenCalledWith(
+        'workbench.action.browser.open',
+        saveURI.toString(),
+      )
+      expect(env.openExternal).not.toHaveBeenCalled()
+    })
+
+    it('opens in integrated browser window when doExport() returns autoOpen config for window', async () => {
+      exportResult.autoOpen = { integratedBrowser: 'window' }
+
+      await exportModule.saveDialog(document)
+
+      expect(commands.executeCommand).toHaveBeenNthCalledWith(
+        1,
+        'workbench.action.newEmptyEditorWindow',
+      )
+      expect(commands.executeCommand).toHaveBeenNthCalledWith(
+        2,
+        'workbench.action.enableCompactAuxiliaryWindow',
+      )
+      expect(commands.executeCommand).toHaveBeenNthCalledWith(
+        3,
+        'workbench.action.browser.open',
+        saveURI.toString(),
+      )
+      expect(env.openExternal).not.toHaveBeenCalled()
+    })
+
+    it('falls back to open in external when doExport() returns autoOpen config for the integrated browser but command is unavailable', async () => {
+      exportResult.autoOpen = { integratedBrowser: 'tab' }
+      ;(commands.getCommands as jest.Mock).mockResolvedValue([])
+
+      await exportModule.saveDialog(document)
+
+      expect(commands.getCommands).toHaveBeenCalledWith(true)
+      expect(commands.executeCommand).not.toHaveBeenCalledWith(
+        'workbench.action.browser.open',
+        saveURI.toString(),
+      )
+      expect(env.openExternal).toHaveBeenCalledWith(saveURI)
+    })
+
     it('shows error message when doExport() returns with error field', async () => {
       exportResult.error = 'ERROR'
 
@@ -466,6 +515,122 @@ describe('#doExport', () => {
         }
       },
     )
+  })
+
+  describe('when set markdown.marp.openExportedHtmlInIntegratedBrowser', () => {
+    let marpCliMock: jest.SpyInstance
+
+    beforeEach(() => {
+      marpCliMock = jest.spyOn(marpCli, 'default').mockImplementation()
+      setConfiguration({ 'markdown.marp.exportAutoOpen': true })
+    })
+
+    afterEach(() => marpCliMock?.mockRestore())
+
+    it('returns autoOpen with integratedBrowser as false while exporting HTML if set as "off"', async () => {
+      setConfiguration({
+        'markdown.marp.openExportedHtmlInIntegratedBrowser': 'off',
+      })
+
+      expect(
+        await exportModule.doExport(saveURI('file', 'html'), document),
+      ).toStrictEqual(
+        expect.objectContaining({ autoOpen: { integratedBrowser: false } }),
+      )
+    })
+
+    it('returns autoOpen with integratedBrowser as "tab" while exporting HTML if set as "tab"', async () => {
+      setConfiguration({
+        'markdown.marp.openExportedHtmlInIntegratedBrowser': 'tab',
+      })
+
+      expect(
+        await exportModule.doExport(saveURI('file', 'html'), document),
+      ).toStrictEqual(
+        expect.objectContaining({ autoOpen: { integratedBrowser: 'tab' } }),
+      )
+    })
+
+    it('returns autoOpen with integratedBrowser as false while exporting non HTML file if set as "tab"', async () => {
+      setConfiguration({
+        'markdown.marp.openExportedHtmlInIntegratedBrowser': 'tab',
+      })
+
+      expect(
+        await exportModule.doExport(saveURI('file', 'pdf'), document),
+      ).toStrictEqual(
+        expect.objectContaining({ autoOpen: { integratedBrowser: false } }),
+      )
+    })
+
+    it('returns autoOpen with false while exporting HTML if set as "tab" but auto open is disabled', async () => {
+      setConfiguration({
+        'markdown.marp.exportAutoOpen': false,
+        'markdown.marp.openExportedHtmlInIntegratedBrowser': 'tab',
+      })
+
+      expect(
+        await exportModule.doExport(saveURI('file', 'html'), document),
+      ).toStrictEqual(expect.objectContaining({ autoOpen: false }))
+    })
+
+    it('returns autoOpen with false while exporting HTML to non-file scheme if set as "tab"', async () => {
+      setConfiguration({
+        'markdown.marp.openExportedHtmlInIntegratedBrowser': 'tab',
+      })
+
+      const isWritableFileSystemMock = jest
+        .spyOn(workspace.fs, 'isWritableFileSystem')
+        .mockReturnValue(true)
+
+      try {
+        expect(
+          await exportModule.doExport(
+            saveURI('unknown-scheme', 'html'),
+            document,
+          ),
+        ).toStrictEqual(expect.objectContaining({ autoOpen: false }))
+      } finally {
+        isWritableFileSystemMock.mockRestore()
+      }
+    })
+
+    it('returns autoOpen with integratedBrowser as "tab" while exporting with unknown extension if set as "tab"', async () => {
+      setConfiguration({
+        'markdown.marp.openExportedHtmlInIntegratedBrowser': 'tab',
+      })
+
+      expect(
+        await exportModule.doExport(saveURI('file', 'unknown'), document),
+      ).toStrictEqual(
+        // Marp CLI treats the output path with unknown extension as HTML, so the result can open in the integrated browser
+        expect.objectContaining({ autoOpen: { integratedBrowser: 'tab' } }),
+      )
+    })
+
+    it('returns autoOpen with integratedBrowser as "window" while exporting HTML if set as "window"', async () => {
+      setConfiguration({
+        'markdown.marp.openExportedHtmlInIntegratedBrowser': 'window',
+      })
+
+      expect(
+        await exportModule.doExport(saveURI('file', 'html'), document),
+      ).toStrictEqual(
+        expect.objectContaining({ autoOpen: { integratedBrowser: 'window' } }),
+      )
+    })
+
+    it('returns autoOpen with integratedBrowser as false while exporting HTML if set as "unknown"', async () => {
+      setConfiguration({
+        'markdown.marp.openExportedHtmlInIntegratedBrowser': 'unknown',
+      })
+
+      expect(
+        await exportModule.doExport(saveURI('file', 'html'), document),
+      ).toStrictEqual(
+        expect.objectContaining({ autoOpen: { integratedBrowser: false } }),
+      )
+    })
   })
 
   describe('when CLI was thrown CLIError with NOT_FOUND_SOFFICE error code', () => {

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -67,9 +67,14 @@ const chromiumRequiredExtensions = [
   ...extensions.jpeg,
 ] as string[]
 
+const nonHtmlExtname = Object.values(extensions)
+  .flat()
+  .filter((ext) => ext !== 'html')
+  .map((ext) => `.${ext}`)
+
 export interface ExportResult {
   uri: Uri
-  autoOpen?: boolean
+  autoOpen?: boolean | { integratedBrowser?: false | 'tab' | 'window' }
   error?: string
 }
 
@@ -252,12 +257,23 @@ export const doExport = async (
           }
         }
 
-        return {
-          uri,
-          autoOpen:
-            marpConfiguration().get<boolean>('exportAutoOpen') &&
-            outputToLocalFS, // Only local files can open in a relevant application
-        }
+        const autoOpen = (() => {
+          if (!outputToLocalFS) return false // Only local files can open in a relevant application
+          if (!marpConfiguration().get<boolean>('exportAutoOpen')) return false
+
+          // HTML file may open in the integrated browser (Marp CLI treats unexpected extensions as HTML)
+          if (!nonHtmlExtname.includes(outputExt)) {
+            const config = marpConfiguration().get<'off' | 'tab' | 'window'>(
+              'openExportedHtmlInIntegratedBrowser',
+            )
+
+            if (config === 'tab' || config === 'window')
+              return { integratedBrowser: config }
+          }
+          return { integratedBrowser: false } as const
+        })()
+
+        return { uri, autoOpen }
       }
 
       return await runMarpCli({
@@ -316,7 +332,26 @@ export const saveDialog = async (document: TextDocument) => {
     if (result.error) {
       window.showErrorMessage(result.error)
     } else if (result.autoOpen) {
-      env.openExternal(result.uri)
+      if (
+        typeof result.autoOpen === 'object' &&
+        result.autoOpen.integratedBrowser &&
+        (await commands.getCommands(true)).includes(
+          'workbench.action.browser.open',
+        )
+      ) {
+        if (result.autoOpen.integratedBrowser === 'window') {
+          await commands.executeCommand('workbench.action.newEmptyEditorWindow')
+          await commands.executeCommand(
+            'workbench.action.enableCompactAuxiliaryWindow',
+          )
+        }
+        await commands.executeCommand(
+          'workbench.action.browser.open',
+          result.uri.toString(),
+        )
+      } else {
+        env.openExternal(result.uri)
+      }
     } else {
       // Show success message if the auto open was disabled. It includes
       // when the output is not local file: Remote path, Virtual file, etc.


### PR DESCRIPTION
This PR adds an experimental `markdown.marp.openExportedHtmlInIntegratedBrowser` setting to open the exported HTML in [the VS Code integrated browser](https://code.visualstudio.com/docs/debugtest/integrated-browser) instead of the external browser app.

- `off`: The exported HTML will open in the external browser app.
- `tab`: The exported HTML will open in the integrated browser as a new tab.
- `window`: The exported HTML will open in the integrated browser as a new window.

Users can view the exported presentation within VS Code. The external window for the presenter view is also working.

**Restriction**: [VS Code denys the full-screen view in the integrated browser](https://code.visualstudio.com/docs/debugtest/integrated-browser#_permissions), so the full-screen toggle provided by Marp CLI's bespoke template won't work. _That means this setting is not helpful in the traditional presentation with sharing full screen._

Related: #87