### PR TITLE
Try to fix "TypeError: File URL path must be absolute" on Windows

### DIFF
--- a/src/commands/export.test.ts
+++ b/src/commands/export.test.ts
@@ -1,5 +1,5 @@
 import * as marpCliModule from '@marp-team/marp-cli'
-import open from 'open'
+import { execFile as openFile } from 'node:child_process'
 import { commands, env, window, workspace } from 'vscode'
 import type { Uri } from 'vscode'
 import * as marpCli from '../marp-cli'
@@ -10,7 +10,7 @@ import * as exportModule from './export'
 const exportCommand = exportModule.default
 
 jest.mock('fs')
-jest.mock('open')
+jest.mock('node:child_process')
 jest.mock('vscode')
 jest.mock('../workspace-proxy-server', () => ({
   createWorkspaceProxyServer: jest.fn().mockResolvedValue({
@@ -211,7 +211,10 @@ describe('#saveDialog', () => {
 
         await exportModule.saveDialog(document)
 
-        expect(open).toHaveBeenCalledWith(nonAsciiSaveURI.fsPath)
+        expect(openFile).toHaveBeenCalledWith('rundll32', [
+          'url.dll,FileProtocolHandler',
+          nonAsciiSaveURI.fsPath,
+        ])
         expect(env.openExternal).not.toHaveBeenCalled()
       } finally {
         Object.defineProperty(process, 'platform', { value: originalPlatform })

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -1,7 +1,7 @@
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { nanoid } from 'nanoid'
-import open from 'open'
+import { execFile as openFile } from 'node:child_process'
 import {
   commands,
   env,
@@ -361,7 +361,13 @@ export const saveDialog = async (document: TextDocument) => {
           result.uri.scheme === 'file' &&
           result.uri.toString().includes('%')
         ) {
-          await open(result.uri.fsPath)
+          // Use native rundll32 via Gemini's suggestion to avoid the 'open' module's 
+          // activation crash on Windows (TypeError: File URL path must be absolute).
+          // This approach bypasses ESM-related bundler issues.
+          openFile('rundll32', [
+            'url.dll,FileProtocolHandler',
+            result.uri.fsPath,
+          ])
         } else {
           env.openExternal(result.uri)
         }


### PR DESCRIPTION
Problem:
The extension crashes during activation on Windows with `TypeError: File URL path must be absolute.`

Cause:
The open module relies on import.meta.url, which causes issues in the production bundle on Windows.

Fix:
Replaced open with native rundll32 to handle non-ASCII paths. This avoids ESM resolution issues in the extension host while keeping the fix for #556.

Developed and verified using Gemini. 

**Please review** the changes before merging.