### PR TITLE
Fix broken bundle on Windows by making the `open` module an external dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix broken bundle on Windows by making the `open` module an external dependency ([#559](https://github.com/marp-team/marp-vscode/issues/559), [#561](https://github.com/marp-team/marp-vscode/pull/561))
+
 ## v3.5.0 - 2026-05-03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -436,7 +436,6 @@
     "nanoid": "^5.1.9",
     "npm-check-updates": "^22.0.1",
     "npm-run-all2": "^8.0.4",
-    "open": "^11.0.0",
     "os-browserify": "^0.3.0",
     "path-browserify": "^1.0.1",
     "portfinder": "^1.0.38",
@@ -461,6 +460,7 @@
     "yaml": "^2.8.3"
   },
   "dependencies": {
-    "@marp-team/marp-cli": "^4.3.1"
+    "@marp-team/marp-cli": "^4.3.1",
+    "open": "^11.0.0"
   }
 }

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -1,7 +1,6 @@
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { nanoid } from 'nanoid'
-import open from 'open'
 import {
   commands,
   env,
@@ -361,7 +360,7 @@ export const saveDialog = async (document: TextDocument) => {
           result.uri.scheme === 'file' &&
           result.uri.toString().includes('%')
         ) {
-          await open(result.uri.fsPath)
+          await (await import('open')).default(result.uri.fsPath)
         } else {
           env.openExternal(result.uri)
         }


### PR DESCRIPTION
Fix #559.

webpack tries to bundle `import.meta.url` to a stuck string on the build time, so Windows environment fails initializing `open` module due to incorrect environment detection.

- Make the `open` module an external dependency. It means that the bundler no longer transpile the internal logic.
- Apply lazy loading to `open`.