### PR TITLE
Check the path traversal strictly while theme path normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Security
+
+- Fix theme path traversal check incorrectly passing for specific directory structures ([#567](https://github.com/marp-team/marp-vscode/issues/567), [#568](https://github.com/marp-team/marp-vscode/pull/568))
+
 ## v3.5.1 - 2026-05-04
 
 ### Fixed

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -483,13 +483,20 @@ describe('#getExtendMarkdownIt', () => {
           .spyOn(workspace.fs, 'readFile')
           .mockResolvedValue(new TextEncoder().encode(css))
 
+        /*
+         * /test/path
+         *   ├── {workspace} ← VS Code opened workspace folder
+         *   │   └── markdown.md
+         *   └── workspace.css ← ❌ Out of workspace so expected not to load
+         */
         try {
-          setConfiguration({ 'markdown.marp.themes': ['../test.css'] })
+          setConfiguration({ 'markdown.marp.themes': ['../workspace.css'] })
 
           const markdown = md()
-          markdown.normalizeLink = (url) => path.resolve(baseDir, url)
+          const workspaceDir = path.resolve(baseDir, 'workspace') // /test/path/workspace
 
-          await Promise.all(themes.loadStyles(Uri.parse(baseDir)))
+          await Promise.all(themes.loadStyles(Uri.file(workspaceDir)))
+          expect(readFileMock).not.toHaveBeenCalled()
           expect(
             markdown.render(marpMd('<!--theme: example-->')),
           ).not.toContain(css)

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -131,7 +131,10 @@ export class Themes {
         const targetUri = Uri.joinPath(rootUri, p)
 
         // Prevent directory traversal
-        if (targetUri.path.startsWith(rootUri.path)) {
+        if (
+          targetUri.path === rootUri.path ||
+          targetUri.path.startsWith(`${rootUri.path}/`)
+        ) {
           normalizedPaths.add(targetUri)
         }
       }


### PR DESCRIPTION
Fixed #567. 

A simple `startsWith` check may unexpectedly pass the check of directory traversal in a particular structure (9f81782).